### PR TITLE
improve definition of VMCS and VMXON

### DIFF
--- a/out/ia32.h
+++ b/out/ia32.h
@@ -18972,21 +18972,38 @@ typedef struct
  */
 typedef struct
 {
-  /**
-   * @brief VMCS revision identifier
-   *
-   * Processors that maintain VMCS data in different formats (see below) use different VMCS revision identifiers. These
-   * identifiers enable software to avoid using a VMCS region formatted for one processor on a processor that uses a
-   * different format. Software should write the VMCS revision identifier to the VMCS region before using that region for a
-   * VMCS. The VMCS revision identifier is never written by the processor; VMPTRLD fails if its operand references a VMCS
-   * region whose VMCS revision identifier differs from that used by the processor (VMPTRLD also fails if the shadow-VMCS
-   * indicator is 1 and the processor does not support the 1-setting of the "VMCS shadowing" VM-execution control. Software
-   * can discover the VMCS revision identifier that a processor uses by reading the VMX capability MSR IA32_VMX_BASIC.
-   *
-   * @see Vol3C[24.6.2(Processor-Based VM-Execution Controls)]
-   * @see Vol3D[A.1(BASIC VMX INFORMATION)]
-   */
-  UINT32 RevisionId;
+  struct
+  {
+    /**
+     * @brief VMCS revision identifier
+     *
+     * [Bits 30:0] Processors that maintain VMCS data in different formats (see below) use different VMCS revision identifiers.
+     * These identifiers enable software to avoid using a VMCS region formatted for one processor on a processor that uses a
+     * different format.
+     * Software should write the VMCS revision identifier to the VMCS region before using that region for a VMCS. The VMCS
+     * revision identifier is never written by the processor; VMPTRLD fails if its operand references a VMCS region whose VMCS
+     * revision identifier differs from that used by the processor.
+     * Software can discover the VMCS revision identifier that a processor uses by reading the VMX capability MSR
+     * IA32_VMX_BASIC.
+     *
+     * @see Vol3C[24.6.2(Processor-Based VM-Execution Controls)]
+     * @see Vol3D[A.1(BASIC VMX INFORMATION)]
+     */
+    UINT32 RevisionId                                              : 31;
+
+    /**
+     * @brief Shadow-VMCS indicator
+     *
+     * [Bit 31] Software should clear or set the shadow-VMCS indicator depending on whether the VMCS is to be an ordinary VMCS
+     * or a shadow VMCS. VMPTRLD fails if the shadow-VMCS indicator is set and the processor does not support the 1-setting of
+     * the "VMCS shadowing" VM-execution control. Software can discover support for this setting by reading the VMX capability
+     * MSR IA32_VMX_PROCBASED_CTLS2.
+     *
+     * @see Vol3C[24.10(VMCS TYPES ORDINARY AND SHADOW)]
+     */
+    UINT32 ShadowVmcsIndicator                                     : 1;
+  };
+
 
   /**
    * @brief VMX-abort indicator
@@ -19024,18 +19041,27 @@ typedef struct
  */
 typedef struct
 {
-  /**
-   * @brief VMCS revision identifier
-   *
-   * Before executing VMXON, software should write the VMCS revision identifier to the VMXON region. (Specifically, it should
-   * write the 31-bit VMCS revision identifier to bits 30:0 of the first 4 bytes of the VMXON region; bit 31 should be
-   * cleared to 0.)
-   *
-   * @see VMCS
-   * @see Vol3C[24.2(FORMAT OF THE VMCS REGION)]
-   * @see Vol3D[A.1(BASIC VMX INFORMATION)]
-   */
-  UINT32 RevisionId;
+  struct
+  {
+    /**
+     * @brief VMCS revision identifier
+     *
+     * [Bits 30:0] Before executing VMXON, software should write the VMCS revision identifier to the VMXON region.
+     * (Specifically, it should write the 31-bit VMCS revision identifier to bits 30:0 of the first 4 bytes of the VMXON
+     * region; bit 31 should be cleared to 0.)
+     *
+     * @see VMCS
+     * @see Vol3C[24.2(FORMAT OF THE VMCS REGION)]
+     * @see Vol3C[24.11.5(VMXON Region)]
+     */
+    UINT32 RevisionId                                              : 31;
+
+    /**
+     * [Bit 31] Bit 31 is always 0.
+     */
+    UINT32 MustBeZero                                              : 1;
+  };
+
 
   /**
    * @brief VMXON data (implementation-specific format)

--- a/out/ia32.hpp
+++ b/out/ia32.hpp
@@ -18972,21 +18972,38 @@ typedef struct
  */
 typedef struct
 {
-  /**
-   * @brief VMCS revision identifier
-   *
-   * Processors that maintain VMCS data in different formats (see below) use different VMCS revision identifiers. These
-   * identifiers enable software to avoid using a VMCS region formatted for one processor on a processor that uses a
-   * different format. Software should write the VMCS revision identifier to the VMCS region before using that region for a
-   * VMCS. The VMCS revision identifier is never written by the processor; VMPTRLD fails if its operand references a VMCS
-   * region whose VMCS revision identifier differs from that used by the processor (VMPTRLD also fails if the shadow-VMCS
-   * indicator is 1 and the processor does not support the 1-setting of the "VMCS shadowing" VM-execution control. Software
-   * can discover the VMCS revision identifier that a processor uses by reading the VMX capability MSR IA32_VMX_BASIC.
-   *
-   * @see Vol3C[24.6.2(Processor-Based VM-Execution Controls)]
-   * @see Vol3D[A.1(BASIC VMX INFORMATION)]
-   */
-  uint32_t revision_id;
+  struct
+  {
+    /**
+     * @brief VMCS revision identifier
+     *
+     * [Bits 30:0] Processors that maintain VMCS data in different formats (see below) use different VMCS revision identifiers.
+     * These identifiers enable software to avoid using a VMCS region formatted for one processor on a processor that uses a
+     * different format.
+     * Software should write the VMCS revision identifier to the VMCS region before using that region for a VMCS. The VMCS
+     * revision identifier is never written by the processor; VMPTRLD fails if its operand references a VMCS region whose VMCS
+     * revision identifier differs from that used by the processor.
+     * Software can discover the VMCS revision identifier that a processor uses by reading the VMX capability MSR
+     * IA32_VMX_BASIC.
+     *
+     * @see Vol3C[24.6.2(Processor-Based VM-Execution Controls)]
+     * @see Vol3D[A.1(BASIC VMX INFORMATION)]
+     */
+    uint32_t revision_id                                             : 31;
+
+    /**
+     * @brief Shadow-VMCS indicator
+     *
+     * [Bit 31] Software should clear or set the shadow-VMCS indicator depending on whether the VMCS is to be an ordinary VMCS
+     * or a shadow VMCS. VMPTRLD fails if the shadow-VMCS indicator is set and the processor does not support the 1-setting of
+     * the "VMCS shadowing" VM-execution control. Software can discover support for this setting by reading the VMX capability
+     * MSR IA32_VMX_PROCBASED_CTLS2.
+     *
+     * @see Vol3C[24.10(VMCS TYPES ORDINARY AND SHADOW)]
+     */
+    uint32_t shadow_vmcs_indicator                                   : 1;
+  };
+
 
   /**
    * @brief VMX-abort indicator
@@ -19024,18 +19041,27 @@ typedef struct
  */
 typedef struct
 {
-  /**
-   * @brief VMCS revision identifier
-   *
-   * Before executing VMXON, software should write the VMCS revision identifier to the VMXON region. (Specifically, it should
-   * write the 31-bit VMCS revision identifier to bits 30:0 of the first 4 bytes of the VMXON region; bit 31 should be
-   * cleared to 0.)
-   *
-   * @see VMCS
-   * @see Vol3C[24.2(FORMAT OF THE VMCS REGION)]
-   * @see Vol3D[A.1(BASIC VMX INFORMATION)]
-   */
-  uint32_t revision_id;
+  struct
+  {
+    /**
+     * @brief VMCS revision identifier
+     *
+     * [Bits 30:0] Before executing VMXON, software should write the VMCS revision identifier to the VMXON region.
+     * (Specifically, it should write the 31-bit VMCS revision identifier to bits 30:0 of the first 4 bytes of the VMXON
+     * region; bit 31 should be cleared to 0.)
+     *
+     * @see VMCS
+     * @see Vol3C[24.2(FORMAT OF THE VMCS REGION)]
+     * @see Vol3C[24.11.5(VMXON Region)]
+     */
+    uint32_t revision_id                                             : 31;
+
+    /**
+     * [Bit 31] Bit 31 is always 0.
+     */
+    uint32_t must_be_zero                                            : 1;
+  };
+
 
   /**
    * @brief VMXON data (implementation-specific format)

--- a/out/ia32_compact.h
+++ b/out/ia32_compact.h
@@ -4538,13 +4538,21 @@ typedef struct {
 } invvpid_descriptor;
 
 typedef struct {
-  uint32_t revision_id;
+  struct {
+    uint32_t revision_id                                             : 31;
+    uint32_t shadow_vmcs_indicator                                   : 1;
+  };
+
   uint32_t abort_indicator;
   uint8_t data[4088];
 } vmcs;
 
 typedef struct {
-  uint32_t revision_id;
+  struct {
+    uint32_t revision_id                                             : 31;
+    uint32_t must_be_zero                                            : 1;
+  };
+
   uint8_t data[4092];
 } vmxon;
 

--- a/out/ia32_defines_only.h
+++ b/out/ia32_defines_only.h
@@ -5836,13 +5836,21 @@ typedef struct {
 } invvpid_descriptor;
 
 typedef struct {
-  uint32_t revision_id;
+  struct {
+    uint32_t revision_id                                             : 31;
+    uint32_t shadow_vmcs_indicator                                   : 1;
+  };
+
   uint32_t abort_indicator;
   uint8_t data[4088];
 } vmcs;
 
 typedef struct {
-  uint32_t revision_id;
+  struct {
+    uint32_t revision_id                                             : 31;
+    uint32_t must_be_zero                                            : 1;
+  };
+
   uint8_t data[4092];
 } vmxon;
 

--- a/yaml/Intel/VMX/VMCS.yml
+++ b/yaml/Intel/VMX/VMCS.yml
@@ -12,22 +12,37 @@
   size: 32768
   reference: Vol3C[24.2(FORMAT OF THE VMCS REGION)]
   fields:
-  - size: 32
-    name: REVISION_ID
-    short_description: VMCS revision identifier.
-    long_description: |
-      Processors that maintain VMCS data in different formats (see below) use different VMCS revision identifiers.
-      These identifiers enable software to avoid using a VMCS region formatted for one processor on a processor
-      that uses a different format.
-      Software should write the VMCS revision identifier to the VMCS region before using that region for a VMCS. The
-      VMCS revision identifier is never written by the processor; VMPTRLD fails if its operand references a VMCS region
-      whose VMCS revision identifier differs from that used by the processor (VMPTRLD also fails if the shadow-VMCS
-      indicator is 1 and the processor does not support the 1-setting of the “VMCS shadowing” VM-execution control.
-      Software can discover the VMCS revision identifier that a processor uses by reading the VMX capability
-      MSR IA32_VMX_BASIC.
-    see:
-    - Vol3C[24.6.2(Processor-Based VM-Execution Controls)]
-    - Vol3D[A.1(BASIC VMX INFORMATION)]
+  - type: bitfield
+    size: 32
+    fields:
+      - bit: 0-30
+        name: REVISION_ID
+        short_description: VMCS revision identifier.
+        long_description: |
+          Processors that maintain VMCS data in different formats (see below) use different VMCS revision identifiers.
+          These identifiers enable software to avoid using a VMCS region formatted for one processor on a processor
+          that uses a different format.
+
+          Software should write the VMCS revision identifier to the VMCS region before using that region for a VMCS. The
+          VMCS revision identifier is never written by the processor; VMPTRLD fails if its operand references a VMCS region
+          whose VMCS revision identifier differs from that used by the processor.
+
+          Software can discover the VMCS revision identifier that a processor uses by reading the VMX capability
+          MSR IA32_VMX_BASIC.
+        see:
+        - Vol3C[24.6.2(Processor-Based VM-Execution Controls)]
+        - Vol3D[A.1(BASIC VMX INFORMATION)]
+
+      - bit: 31
+        name: SHADOW_VMCS_INDICATOR
+        short_description: Shadow-VMCS indicator.
+        long_description: |
+          Software should clear or set the shadow-VMCS indicator depending on whether the VMCS is to be an ordinary
+          VMCS or a shadow VMCS. VMPTRLD fails if the shadow-VMCS indicator is set and the processor does not support
+          the 1-setting of the "VMCS shadowing" VM-execution control. Software can discover support for this setting
+          by reading the VMX capability MSR IA32_VMX_PROCBASED_CTLS2.
+        see:
+        - Vol3C[24.10(VMCS TYPES ORDINARY AND SHADOW)]
 
   - size: 32
     name: ABORT_INDICATOR
@@ -64,17 +79,24 @@
   size: 32768
   reference: Vol3C[24.11.5(VMXON Region)]
   fields:
-  - size: 32
-    name: REVISION_ID
-    short_description: VMCS revision identifier.
-    long_description: |
-      Before executing VMXON, software should write the VMCS revision identifier to the VMXON region.
-      (Specifically, it should write the 31-bit VMCS revision identifier to bits 30:0 of the first 4 bytes of
-      the VMXON region; bit 31 should be cleared to 0.)
-    see:
-    - VMCS
-    - Vol3C[24.2(FORMAT OF THE VMCS REGION)]
-    - Vol3D[A.1(BASIC VMX INFORMATION)]
+  - type: bitfield
+    size: 32
+    fields:
+      - bit: 0-30
+        name: REVISION_ID
+        short_description: VMCS revision identifier.
+        long_description: |
+          Before executing VMXON, software should write the VMCS revision identifier to the VMXON region.
+          (Specifically, it should write the 31-bit VMCS revision identifier to bits 30:0 of the first 4 bytes of
+          the VMXON region; bit 31 should be cleared to 0.)
+        see:
+        - VMCS
+        - Vol3C[24.2(FORMAT OF THE VMCS REGION)]
+        - Vol3C[24.11.5(VMXON Region)]
+
+      - bit: 31
+        name: MUST_BE_ZERO
+        description: Bit 31 is always 0.
 
   - size: '?'
     name: DATA


### PR DESCRIPTION
This PR updates definition of VMCS and VMXON regions by adding the shadow-VMCS indicator and "must by 0" fields at its bit 31. Header files are updated accordingly.  

Note that this is a breaking change, as writing to `RevisionId` no longer modifies its bit 31. Code like below may leave the shadow-VMCS indicator or "must by 0" fields non-zero.
```cpp
Vmxon->RevisionId = Id;   
//Vmxon->MustBeZero = 0;     // This may be required now
```

Also, the description of the `RevisionId` field in VMCS is cleaned up and some information is moved for the shadow-VMCS indicator field.