### PR TITLE
Addition of multiple definitions and accompanying header updates

### DIFF
--- a/out/ia32.h
+++ b/out/ia32.h
@@ -10710,7 +10710,26 @@ typedef union
 #define IA32_VMX_ENTRY_CTLS_CONCEAL_VMX_FROM_PT_FLAG                 0x20000
 #define IA32_VMX_ENTRY_CTLS_CONCEAL_VMX_FROM_PT_MASK                 0x01
 #define IA32_VMX_ENTRY_CTLS_CONCEAL_VMX_FROM_PT(_)                   (((_) >> 17) & 0x01)
-    UINT64 Reserved4                                               : 46;
+
+    /**
+     * [Bit 18] This control determines whether the IA32_RTIT_CTL MSR is loaded on VM entry.
+     */
+    UINT64 LoadIa32RtitCtl                                         : 1;
+#define IA32_VMX_ENTRY_CTLS_LOAD_IA32_RTIT_CTL_BIT                   18
+#define IA32_VMX_ENTRY_CTLS_LOAD_IA32_RTIT_CTL_FLAG                  0x40000
+#define IA32_VMX_ENTRY_CTLS_LOAD_IA32_RTIT_CTL_MASK                  0x01
+#define IA32_VMX_ENTRY_CTLS_LOAD_IA32_RTIT_CTL(_)                    (((_) >> 18) & 0x01)
+    UINT64 Reserved4                                               : 1;
+
+    /**
+     * [Bit 20] This control determines whether CET-related MSRs and SPP are loaded on VM entry.
+     */
+    UINT64 LoadCetState                                            : 1;
+#define IA32_VMX_ENTRY_CTLS_LOAD_CET_STATE_BIT                       20
+#define IA32_VMX_ENTRY_CTLS_LOAD_CET_STATE_FLAG                      0x100000
+#define IA32_VMX_ENTRY_CTLS_LOAD_CET_STATE_MASK                      0x01
+#define IA32_VMX_ENTRY_CTLS_LOAD_CET_STATE(_)                        (((_) >> 20) & 0x01)
+    UINT64 Reserved5                                               : 43;
   };
 
   UINT64 Flags;
@@ -13959,6 +13978,19 @@ typedef union
 } PT_ENTRY_32;
 
 /**
+ * @defgroup PAGING_STRUCTURES_ENTRY_COUNT_32 \
+ *           Paging structures entry counts
+ *
+ * Paging structures entry counts.
+ * @{
+ */
+#define PDE_ENTRY_COUNT_32                                           0x00000400
+#define PTE_ENTRY_COUNT_32                                           0x00000400
+/**
+ * @}
+ */
+
+/**
  * @}
  */
 
@@ -14957,6 +14989,21 @@ typedef union
 
   UINT64 Flags;
 } PT_ENTRY_64;
+
+/**
+ * @defgroup PAGING_STRUCTURES_ENTRY_COUNT_64 \
+ *           Paging structures entry counts
+ *
+ * Paging structures entry counts.
+ * @{
+ */
+#define PML4E_ENTRY_COUNT_64                                         0x00000200
+#define PDPTE_ENTRY_COUNT_64                                         0x00000200
+#define PDE_ENTRY_COUNT_64                                           0x00000200
+#define PTE_ENTRY_COUNT_64                                           0x00000200
+/**
+ * @}
+ */
 
 /**
  * @}
@@ -16359,9 +16406,9 @@ typedef union
 
 /**
  * @defgroup VMX_INSTRUCTION_ERROR_NUMBERS \
- *           VM Instruction Error Numbers
+ *           VM-Instruction Error Numbers
  *
- * VM Instruction Error Numbers.
+ * VM-Instruction Error Numbers.
  *
  * @see Vol3C[30.4(VM INSTRUCTION ERROR NUMBERS)] (reference)
  * @{
@@ -18871,6 +18918,7 @@ typedef union
 #define EPT_PML4E_ENTRY_COUNT                                        0x00000200
 #define EPT_PDPTE_ENTRY_COUNT                                        0x00000200
 #define EPT_PDE_ENTRY_COUNT                                          0x00000200
+#define EPT_PTE_ENTRY_COUNT                                          0x00000200
 /**
  * @}
  */
@@ -20066,6 +20114,21 @@ typedef union
  * Guest IA32_SYSENTER_EIP.
  */
 #define VMCS_GUEST_SYSENTER_EIP                                      0x00006826
+
+/**
+ * Guest IA32_S_CET.
+ */
+#define VMCS_GUEST_S_CET                                             0x00006C28
+
+/**
+ * Guest SSP.
+ */
+#define VMCS_GUEST_SSP                                               0x00006C2A
+
+/**
+ * Guest IA32_INTERRUPT_SSP_TABLE_ADDR.
+ */
+#define VMCS_GUEST_INTERRUPT_SSP_TABLE_ADDR                          0x00006C2C
 /**
  * @}
  */
@@ -20136,6 +20199,21 @@ typedef union
  * Host RIP.
  */
 #define VMCS_HOST_RIP                                                0x00006C16
+
+/**
+ * Host IA32_S_CET.
+ */
+#define VMCS_HOST_S_CET                                              0x00006C18
+
+/**
+ * Host SSP.
+ */
+#define VMCS_HOST_SSP                                                0x00006C1A
+
+/**
+ * Host IA32_INTERRUPT_SSP_TABLE_ADDR.
+ */
+#define VMCS_HOST_INTERRUPT_SSP_TABLE_ADDR                           0x00006C1C
 /**
  * @}
  */
@@ -21061,6 +21139,14 @@ typedef enum
   Debug                                                        = 0x00000001,
 
   /**
+   * Nonmaskable Interrupt.
+   * Source: Generated externally by asserting the processor's NMI pin or
+   *         through an NMI request set by the I/O APIC to the local APIC.
+   * Error Code: No.
+   */
+  Nmi                                                          = 0x00000002,
+
+  /**
    * #BP - Breakpoint.
    * Source: INT3 instruction.
    * Error Code: No.
@@ -21421,6 +21507,15 @@ typedef union
  * memory accesses to insure system memory and cache coherency.
  */
 #define MEMORY_TYPE_WRITE_BACK                                       0x00000006
+
+/**
+ * @brief Uncacheable (UC-)
+ *
+ * Has same characteristics as the strong uncacheable (UC) memory type, except that this memory type can be overridden by
+ * programming the MTRRs for the WC memory type. This memory type is available in processor families starting from the
+ * Pentium III processors and can only be selected through the PAT.
+ */
+#define MEMORY_TYPE_UNCACHEABLE_MINUS                                0x00000007
 #define MEMORY_TYPE_INVALID                                          0x000000FF
 /**
  * @}

--- a/out/ia32_compact.h
+++ b/out/ia32_compact.h
@@ -2867,6 +2867,9 @@ typedef union {
     uint64_t load_ia32_efer                                          : 1;
     uint64_t load_ia32_bndcfgs                                       : 1;
     uint64_t conceal_vmx_from_pt                                     : 1;
+    uint64_t load_ia32_rtit_ctl                                      : 1;
+    uint64_t reserved_4                                              : 1;
+    uint64_t load_cet_state                                          : 1;
   };
 
   uint64_t flags;
@@ -3538,6 +3541,17 @@ typedef union {
 } pt_entry_32;
 
 /**
+ * @defgroup paging_structures_entry_count_32 \
+ *           Paging structures entry counts
+ * @{
+ */
+#define PDE_ENTRY_COUNT_32                                           0x00000400
+#define PTE_ENTRY_COUNT_32                                           0x00000400
+/**
+ * @}
+ */
+
+/**
  * @}
  */
 
@@ -3697,6 +3711,19 @@ typedef union {
 
   uint64_t flags;
 } pt_entry_64;
+
+/**
+ * @defgroup paging_structures_entry_count_64 \
+ *           Paging structures entry counts
+ * @{
+ */
+#define PML4_ENTRY_COUNT_64                                          0x00000200
+#define PDPTE_ENTRY_COUNT_64                                         0x00000200
+#define PDE_ENTRY_COUNT_64                                           0x00000200
+#define PTE_ENTRY_COUNT_64                                           0x00000200
+/**
+ * @}
+ */
 
 /**
  * @}
@@ -3937,7 +3964,7 @@ typedef union {
 
 /**
  * @defgroup vmx_instruction_error_numbers \
- *           VM Instruction Error Numbers
+ *           VM-Instruction Error Numbers
  * @{
  */
 #define VMX_ERROR_VMCALL                                             0x00000001
@@ -4505,6 +4532,7 @@ typedef union {
 #define EPML4_ENTRY_COUNT                                            0x00000200
 #define EPDPTE_ENTRY_COUNT                                           0x00000200
 #define EPDE_ENTRY_COUNT                                             0x00000200
+#define EPTE_ENTRY_COUNT                                             0x00000200
 /**
  * @}
  */
@@ -4871,6 +4899,9 @@ typedef union {
 #define VMCS_GUEST_PENDING_DEBUG_EXCEPTIONS                          0x00006822
 #define VMCS_GUEST_SYSENTER_ESP                                      0x00006824
 #define VMCS_GUEST_SYSENTER_EIP                                      0x00006826
+#define VMCS_GUEST_S_CET                                             0x00006C28
+#define VMCS_GUEST_SSP                                               0x00006C2A
+#define VMCS_GUEST_INTERRUPT_SSP_TABLE_ADDR                          0x00006C2C
 /**
  * @}
  */
@@ -4892,6 +4923,9 @@ typedef union {
 #define VMCS_HOST_SYSENTER_EIP                                       0x00006C12
 #define VMCS_HOST_RSP                                                0x00006C14
 #define VMCS_HOST_RIP                                                0x00006C16
+#define VMCS_HOST_S_CET                                              0x00006C18
+#define VMCS_HOST_SSP                                                0x00006C1A
+#define VMCS_HOST_INTERRUPT_SSP_TABLE_ADDR                           0x00006C1C
 /**
  * @}
  */
@@ -5064,6 +5098,7 @@ typedef union {
 typedef enum {
   divide_error                                                 = 0x00000000,
   debug                                                        = 0x00000001,
+  nmi                                                          = 0x00000002,
   breakpoint                                                   = 0x00000003,
   overflow                                                     = 0x00000004,
   bound_range_exceeded                                         = 0x00000005,
@@ -5123,6 +5158,7 @@ typedef union {
 #define MEMORY_TYPE_WT                                               0x00000004
 #define MEMORY_TYPE_WP                                               0x00000005
 #define MEMORY_TYPE_WB                                               0x00000006
+#define MEMORY_TYPE_UC_MINUS                                         0x00000007
 #define MEMORY_TYPE_INVALID                                          0x000000FF
 /**
  * @}

--- a/out/ia32_defines_only.h
+++ b/out/ia32_defines_only.h
@@ -3639,7 +3639,12 @@ typedef union {
 #define IA32_VMX_ENTRY_CTLS_LOAD_IA32_BNDCFGS                        0x10000
     uint64_t conceal_vmx_from_pt                                     : 1;
 #define IA32_VMX_ENTRY_CTLS_CONCEAL_VMX_FROM_PT                      0x20000
-    uint64_t reserved_4                                              : 46;
+    uint64_t load_ia32_rtit_ctl                                      : 1;
+#define IA32_VMX_ENTRY_CTLS_LOAD_IA32_RTIT_CTL                       0x40000
+    uint64_t reserved_4                                              : 1;
+    uint64_t load_cet_state                                          : 1;
+#define IA32_VMX_ENTRY_CTLS_LOAD_CET_STATE                           0x100000
+    uint64_t reserved_5                                              : 43;
   };
 
   uint64_t Flags;
@@ -4519,6 +4524,17 @@ typedef union {
 } pt_entry_32;
 
 /**
+ * @defgroup paging_structures_entry_count_32 \
+ *           Paging structures entry counts
+ * @{
+ */
+#define PDE_ENTRY_COUNT_32                                           0x00000400
+#define PTE_ENTRY_COUNT_32                                           0x00000400
+/**
+ * @}
+ */
+
+/**
  * @}
  */
 
@@ -4769,6 +4785,19 @@ typedef union {
 
   uint64_t Flags;
 } pt_entry_64;
+
+/**
+ * @defgroup paging_structures_entry_count_64 \
+ *           Paging structures entry counts
+ * @{
+ */
+#define PML4_ENTRY_COUNT_64                                          0x00000200
+#define PDPTE_ENTRY_COUNT_64                                         0x00000200
+#define PDE_ENTRY_COUNT_64                                           0x00000200
+#define PTE_ENTRY_COUNT_64                                           0x00000200
+/**
+ * @}
+ */
 
 /**
  * @}
@@ -5043,7 +5072,7 @@ typedef union {
 
 /**
  * @defgroup vmx_instruction_error_numbers \
- *           VM Instruction Error Numbers
+ *           VM-Instruction Error Numbers
  * @{
  */
 #define VMX_ERROR_VMCALL                                             0x00000001
@@ -5801,6 +5830,7 @@ typedef union {
 #define EPML4_ENTRY_COUNT                                            0x00000200
 #define EPDPTE_ENTRY_COUNT                                           0x00000200
 #define EPDE_ENTRY_COUNT                                             0x00000200
+#define EPTE_ENTRY_COUNT                                             0x00000200
 /**
  * @}
  */
@@ -6175,6 +6205,9 @@ typedef union {
 #define VMCS_GUEST_PENDING_DEBUG_EXCEPTIONS                          0x00006822
 #define VMCS_GUEST_SYSENTER_ESP                                      0x00006824
 #define VMCS_GUEST_SYSENTER_EIP                                      0x00006826
+#define VMCS_GUEST_S_CET                                             0x00006C28
+#define VMCS_GUEST_SSP                                               0x00006C2A
+#define VMCS_GUEST_INTERRUPT_SSP_TABLE_ADDR                          0x00006C2C
 /**
  * @}
  */
@@ -6196,6 +6229,9 @@ typedef union {
 #define VMCS_HOST_SYSENTER_EIP                                       0x00006C12
 #define VMCS_HOST_RSP                                                0x00006C14
 #define VMCS_HOST_RIP                                                0x00006C16
+#define VMCS_HOST_S_CET                                              0x00006C18
+#define VMCS_HOST_SSP                                                0x00006C1A
+#define VMCS_HOST_INTERRUPT_SSP_TABLE_ADDR                           0x00006C1C
 /**
  * @}
  */
@@ -6415,6 +6451,7 @@ typedef union {
  */
 #define DIVIDE_ERROR                                                 0x00000000
 #define DEBUG                                                        0x00000001
+#define NMI                                                          0x00000002
 #define BREAKPOINT                                                   0x00000003
 #define OVERFLOW                                                     0x00000004
 #define BOUND_RANGE_EXCEEDED                                         0x00000005
@@ -6489,6 +6526,7 @@ typedef union {
 #define MEMORY_TYPE_WT                                               0x00000004
 #define MEMORY_TYPE_WP                                               0x00000005
 #define MEMORY_TYPE_WB                                               0x00000006
+#define MEMORY_TYPE_UC_MINUS                                         0x00000007
 #define MEMORY_TYPE_INVALID                                          0x000000FF
 /**
  * @}

--- a/yaml/Intel/Exceptions/ExceptionVector.yml
+++ b/yaml/Intel/Exceptions/ExceptionVector.yml
@@ -30,6 +30,17 @@
 
       Error Code: No.
 
+  - value: 2
+    name: NMI
+    description: |
+      Nonmaskable Interrupt.
+
+      Source: Generated externally by asserting the processor’s NMI pin or
+
+              through an NMI request set by the I/O APIC to the local APIC.
+
+      Error Code: No.
+
   - value: 3
     short_name: BP
     long_name: BREAKPOINT

--- a/yaml/Intel/MemoryType.yml
+++ b/yaml/Intel/MemoryType.yml
@@ -77,5 +77,14 @@
       performance, but it requires that all devices that access system memory on the system bus be able to snoop
       memory accesses to insure system memory and cache coherency.
 
+  - value: 7
+    short_name: UC_MINUS
+    long_name: UNCACHEABLE_MINUS
+    short_description: Uncacheable (UC-)
+    long_description: |
+      Has same characteristics as the strong uncacheable (UC) memory type, except that this memory
+      type can be overridden by programming the MTRRs for the WC memory type. This memory type is available
+      in processor families starting from the Pentium III processors and can only be selected through the PAT.
+
   - value: 0xFF
     name: INVALID

--- a/yaml/Intel/ModelSpecificRegisters/ArchitecturalMsr.yml
+++ b/yaml/Intel/ModelSpecificRegisters/ArchitecturalMsr.yml
@@ -3321,7 +3321,7 @@
       long_description: This control determines whether the IA32_EFER MSR is loaded on VM entry.
 
     - bit: 16
-      short_name: LOAD_BNDCFGS
+      short_name: LOAD_GUEST_BNDCFGS
       long_name: LOAD_IA32_BNDCFGS
       description: This control determines whether the IA32_BNDCFGS MSR is loaded on VM entry.
 
@@ -3331,6 +3331,15 @@
         If this control is 1, Intel Processor Trace does not produce a paging information packet (PIP) on
         a VM entry or a VMCS packet on a VM entry that returns from SMM.
       see: Vol3C[35(INTEL® PROCESSOR TRACE)]
+
+    - bit: 18
+      short_name: LOAD_GUEST_RTIT_CTL
+      long_name: LOAD_IA32_RTIT_CTL
+      description: This control determines whether the IA32_RTIT_CTL MSR is loaded on VM entry.
+
+    - bit: 20
+      name: LOAD_CET_STATE
+      description: This control determines whether CET-related MSRs and SPP are loaded on VM entry.
 
 - value: 0x485
   name: VMX_MISC

--- a/yaml/Intel/Paging/32bit.yml
+++ b/yaml/Intel/Paging/32bit.yml
@@ -275,3 +275,15 @@
       short_name: PFN
       long_name: PAGE_FRAME_NUMBER
       description: Physical address of the 4-KByte page referenced by this entry.
+
+  - name: PAGING_STRUCTURES_ENTRY_COUNT
+    description: Paging structures entry counts.
+    type: group
+    fields:
+    - value: 1024
+      short_name: PDE_ENTRY_COUNT
+      long_name: PDE_ENTRY_COUNT
+
+    - value: 1024
+      short_name: PTE_ENTRY_COUNT
+      long_name: PTE_ENTRY_COUNT

--- a/yaml/Intel/Paging/64bit.yml
+++ b/yaml/Intel/Paging/64bit.yml
@@ -560,3 +560,23 @@
     - bit: 63
       short_name: XD
       long_name: EXECUTE_DISABLE
+
+  - name: PAGING_STRUCTURES_ENTRY_COUNT
+    description: Paging structures entry counts.
+    type: group
+    fields:
+    - value: 512
+      short_name: PML4_ENTRY_COUNT
+      long_name: PML4E_ENTRY_COUNT
+
+    - value: 512
+      short_name: PDPTE_ENTRY_COUNT
+      long_name: PDPTE_ENTRY_COUNT
+
+    - value: 512
+      short_name: PDE_ENTRY_COUNT
+      long_name: PDE_ENTRY_COUNT
+
+    - value: 512
+      short_name: PTE_ENTRY_COUNT
+      long_name: PTE_ENTRY_COUNT

--- a/yaml/Intel/VMX/EPT.yml
+++ b/yaml/Intel/VMX/EPT.yml
@@ -541,6 +541,10 @@
       short_name: EPDE_ENTRY_COUNT
       long_name: EPT_PDE_ENTRY_COUNT
 
+    - value: 512
+      short_name: EPTE_ENTRY_COUNT
+      long_name: EPT_PTE_ENTRY_COUNT
+
 #  - name: EPT_MEMORY_TYPE # TODO: typedef to MEMORY_TYPE
 #    short_description: EPT memory type.
 #    long_description: |

--- a/yaml/Intel/VMX/VMCS.yml
+++ b/yaml/Intel/VMX/VMCS.yml
@@ -999,6 +999,21 @@
           long_name: SYSENTER_EIP
           description: Guest IA32_SYSENTER_EIP.
 
+        - value: 0x6C28
+          short_name: S_CET
+          long_name: S_CET
+          description: Guest IA32_S_CET.
+
+        - value: 0x6C2A
+          short_name: SSP
+          long_name: SSP
+          description: Guest SSP.
+
+        - value: 0x6C2C
+          short_name: INTERRUPT_SSP_TABLE_ADDR
+          long_name: INTERRUPT_SSP_TABLE_ADDR
+          description: Guest IA32_INTERRUPT_SSP_TABLE_ADDR.
+
       - name: NATURAL_WIDTH_HOST_STATE_FIELDS
         description: Natural-Width Host-State Fields.
         children_name_with_prefix: HOST
@@ -1063,3 +1078,18 @@
           short_name: RIP
           long_name: RIP
           description: Host RIP.
+
+        - value: 0x6C18
+          short_name: S_CET
+          long_name: S_CET
+          description: Host IA32_S_CET.
+
+        - value: 0x6C1A
+          short_name: SSP
+          long_name: SSP
+          description: Host SSP.
+
+        - value: 0x6C1C
+          short_name: INTERRUPT_SSP_TABLE_ADDR
+          long_name: INTERRUPT_SSP_TABLE_ADDR
+          description: Host IA32_INTERRUPT_SSP_TABLE_ADDR.

--- a/yaml/Intel/VMX/index.yml
+++ b/yaml/Intel/VMX/index.yml
@@ -526,7 +526,7 @@
           in the logical-AND of the following three values: EDX:EAX, the IA32_XSS MSR, and the XSS-exiting bitmap.
 
     - name: INSTRUCTION_ERROR_NUMBERS
-      description: VM Instruction Error Numbers.
+      description: VM-Instruction Error Numbers.
       children_name_with_prefix: ERROR
       type: group
       reference: Vol3C[30.4(VM INSTRUCTION ERROR NUMBERS)]


### PR DESCRIPTION
This is a collection of definition updates from both old and newer SDM, followed by updates of the header files generated from the updated YAML files. Commits are separated for each relevant change. 

This is not a "directly" breaking change as it only adds new definitions or modifies a name that is not used for the header generation. It is, however, possible that client code would break as always. For example, this code no longer initialize the same bits as it used to.
```
PT_ENTRY_32 pte;
pte.Reserved4 = 0;   // used to initialize  [18:63] but now only initializes [19] 
```

                                               