### PR TITLE
Fix of inconsistent naming with EPT structures, and opportunistic renewal

### DIFF
--- a/out/ia32.h
+++ b/out/ia32.h
@@ -491,7 +491,21 @@ typedef union
 #define CR4_USERMODE_INSTRUCTION_PREVENTION_FLAG                     0x800
 #define CR4_USERMODE_INSTRUCTION_PREVENTION_MASK                     0x01
 #define CR4_USERMODE_INSTRUCTION_PREVENTION(_)                       (((_) >> 11) & 0x01)
-    UINT64 Reserved1                                               : 1;
+
+    /**
+     * @brief 57-bit Linear Addresses
+     *
+     * [Bit 12] When set in IA-32e mode, the processor uses 5-level paging to translate 57-bit linear addresses. When clear in
+     * IA-32e mode, the processor uses 4-level paging to translate 48-bit linear addresses. This bit cannot be modified in
+     * IA-32e mode.
+     *
+     * @see Vol3C[4(PAGING)]
+     */
+    UINT64 LinearAddresses57Bit                                    : 1;
+#define CR4_LINEAR_ADDRESSES_57_BIT_BIT                              12
+#define CR4_LINEAR_ADDRESSES_57_BIT_FLAG                             0x1000
+#define CR4_LINEAR_ADDRESSES_57_BIT_MASK                             0x01
+#define CR4_LINEAR_ADDRESSES_57_BIT(_)                               (((_) >> 12) & 0x01)
 
     /**
      * @brief VMX-Enable
@@ -518,7 +532,7 @@ typedef union
 #define CR4_SMX_ENABLE_FLAG                                          0x4000
 #define CR4_SMX_ENABLE_MASK                                          0x01
 #define CR4_SMX_ENABLE(_)                                            (((_) >> 14) & 0x01)
-    UINT64 Reserved2                                               : 1;
+    UINT64 Reserved1                                               : 1;
 
     /**
      * @brief FSGSBASE-Enable
@@ -562,7 +576,20 @@ typedef union
 #define CR4_OS_XSAVE_FLAG                                            0x40000
 #define CR4_OS_XSAVE_MASK                                            0x01
 #define CR4_OS_XSAVE(_)                                              (((_) >> 18) & 0x01)
-    UINT64 Reserved3                                               : 1;
+
+    /**
+     * @brief Key-Locker-Enable
+     *
+     * [Bit 19] When set, the LOADIWKEY instruction is enabled; in addition, if support for the AES Key Locker instructions has
+     * been activated by system firmware, CPUID.19H:EBX.AESKLE[bit 0] is enumerated as 1 and the AES Key Locker instructions
+     * are enabled. When clear, CPUID.19H:EBX.AESKLE[bit 0] is enumerated as 0 and execution of any Key Locker instruction
+     * causes an invalid-opcode exception (\#UD).
+     */
+    UINT64 KeyLockerEnable                                         : 1;
+#define CR4_KEY_LOCKER_ENABLE_BIT                                    19
+#define CR4_KEY_LOCKER_ENABLE_FLAG                                   0x80000
+#define CR4_KEY_LOCKER_ENABLE_MASK                                   0x01
+#define CR4_KEY_LOCKER_ENABLE(_)                                     (((_) >> 19) & 0x01)
 
     /**
      * @brief SMEP-Enable
@@ -602,7 +629,34 @@ typedef union
 #define CR4_PROTECTION_KEY_ENABLE_FLAG                               0x400000
 #define CR4_PROTECTION_KEY_ENABLE_MASK                               0x01
 #define CR4_PROTECTION_KEY_ENABLE(_)                                 (((_) >> 22) & 0x01)
-    UINT64 Reserved4                                               : 41;
+
+    /**
+     * @brief Control-flow Enforcement Technology
+     *
+     * [Bit 23] Enables control-flow enforcement technology when set. This flag can be set only if CR0.WP is set, and it must
+     * be clear before CR0.WP can be cleared.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 ControlFlowEnforcementEnable                            : 1;
+#define CR4_CONTROL_FLOW_ENFORCEMENT_ENABLE_BIT                      23
+#define CR4_CONTROL_FLOW_ENFORCEMENT_ENABLE_FLAG                     0x800000
+#define CR4_CONTROL_FLOW_ENFORCEMENT_ENABLE_MASK                     0x01
+#define CR4_CONTROL_FLOW_ENFORCEMENT_ENABLE(_)                       (((_) >> 23) & 0x01)
+
+    /**
+     * @brief Enable protection keys for supervisor-mode pages
+     *
+     * [Bit 24] 4-level paging and 5-level paging associate each supervisor-mode linear address with a protection key. When
+     * set, this flag allows use of the IA32_PKRS MSR to specify, for each protection key, whether supervisor-mode linear
+     * addresses with that protection key can be read or written.
+     */
+    UINT64 ProtectionKeyForSupervisorModeEnable                    : 1;
+#define CR4_PROTECTION_KEY_FOR_SUPERVISOR_MODE_ENABLE_BIT            24
+#define CR4_PROTECTION_KEY_FOR_SUPERVISOR_MODE_ENABLE_FLAG           0x1000000
+#define CR4_PROTECTION_KEY_FOR_SUPERVISOR_MODE_ENABLE_MASK           0x01
+#define CR4_PROTECTION_KEY_FOR_SUPERVISOR_MODE_ENABLE(_)             (((_) >> 24) & 0x01)
+    UINT64 Reserved2                                               : 39;
   };
 
   UINT64 Flags;
@@ -2814,7 +2868,109 @@ typedef struct
 #define CPUID_ECX_OSPKE_FLAG                                         0x10
 #define CPUID_ECX_OSPKE_MASK                                         0x01
 #define CPUID_ECX_OSPKE(_)                                           (((_) >> 4) & 0x01)
-      UINT32 Reserved1                                             : 12;
+
+      /**
+       * [Bit 5] WAITPKG.
+       */
+      UINT32 Waitpkg                                               : 1;
+#define CPUID_ECX_WAITPKG_BIT                                        5
+#define CPUID_ECX_WAITPKG_FLAG                                       0x20
+#define CPUID_ECX_WAITPKG_MASK                                       0x01
+#define CPUID_ECX_WAITPKG(_)                                         (((_) >> 5) & 0x01)
+
+      /**
+       * [Bit 6] AVX512_VBMI2.
+       */
+      UINT32 Avx512Vbmi2                                           : 1;
+#define CPUID_ECX_AVX512_VBMI2_BIT                                   6
+#define CPUID_ECX_AVX512_VBMI2_FLAG                                  0x40
+#define CPUID_ECX_AVX512_VBMI2_MASK                                  0x01
+#define CPUID_ECX_AVX512_VBMI2(_)                                    (((_) >> 6) & 0x01)
+
+      /**
+       * [Bit 7] Supports CET shadow stack features if 1. Processors that set this bit define bits 1:0 of the IA32_U_CET and
+       * IA32_S_CET MSRs. Enumerates support for the following MSRs: IA32_INTERRUPT_SPP_TABLE_ADDR, IA32_PL3_SSP, IA32_PL2_SSP,
+       * IA32_PL1_SSP, and IA32_PL0_SSP.
+       */
+      UINT32 CetSs                                                 : 1;
+#define CPUID_ECX_CET_SS_BIT                                         7
+#define CPUID_ECX_CET_SS_FLAG                                        0x80
+#define CPUID_ECX_CET_SS_MASK                                        0x01
+#define CPUID_ECX_CET_SS(_)                                          (((_) >> 7) & 0x01)
+
+      /**
+       * [Bit 8] GFNI.
+       */
+      UINT32 Gfni                                                  : 1;
+#define CPUID_ECX_GFNI_BIT                                           8
+#define CPUID_ECX_GFNI_FLAG                                          0x100
+#define CPUID_ECX_GFNI_MASK                                          0x01
+#define CPUID_ECX_GFNI(_)                                            (((_) >> 8) & 0x01)
+
+      /**
+       * [Bit 9] VAES.
+       */
+      UINT32 Vaes                                                  : 1;
+#define CPUID_ECX_VAES_BIT                                           9
+#define CPUID_ECX_VAES_FLAG                                          0x200
+#define CPUID_ECX_VAES_MASK                                          0x01
+#define CPUID_ECX_VAES(_)                                            (((_) >> 9) & 0x01)
+
+      /**
+       * [Bit 10] VPCLMULQDQ.
+       */
+      UINT32 Vpclmulqdq                                            : 1;
+#define CPUID_ECX_VPCLMULQDQ_BIT                                     10
+#define CPUID_ECX_VPCLMULQDQ_FLAG                                    0x400
+#define CPUID_ECX_VPCLMULQDQ_MASK                                    0x01
+#define CPUID_ECX_VPCLMULQDQ(_)                                      (((_) >> 10) & 0x01)
+
+      /**
+       * [Bit 11] AVX512_VNNI.
+       */
+      UINT32 Avx512Vnni                                            : 1;
+#define CPUID_ECX_AVX512_VNNI_BIT                                    11
+#define CPUID_ECX_AVX512_VNNI_FLAG                                   0x800
+#define CPUID_ECX_AVX512_VNNI_MASK                                   0x01
+#define CPUID_ECX_AVX512_VNNI(_)                                     (((_) >> 11) & 0x01)
+
+      /**
+       * [Bit 12] AVX512_BITALG.
+       */
+      UINT32 Avx512Bitalg                                          : 1;
+#define CPUID_ECX_AVX512_BITALG_BIT                                  12
+#define CPUID_ECX_AVX512_BITALG_FLAG                                 0x1000
+#define CPUID_ECX_AVX512_BITALG_MASK                                 0x01
+#define CPUID_ECX_AVX512_BITALG(_)                                   (((_) >> 12) & 0x01)
+
+      /**
+       * [Bit 13] If 1, the following MSRs are supported: IA32_TME_CAPABILITY, IA32_TME_ACTIVATE, IA32_TME_EXCLUDE_MASK, and
+       * IA32_TME_EXCLUDE_BASE.
+       */
+      UINT32 TmeEn                                                 : 1;
+#define CPUID_ECX_TME_EN_BIT                                         13
+#define CPUID_ECX_TME_EN_FLAG                                        0x2000
+#define CPUID_ECX_TME_EN_MASK                                        0x01
+#define CPUID_ECX_TME_EN(_)                                          (((_) >> 13) & 0x01)
+
+      /**
+       * [Bit 14] AVX512_VPOPCNTDQ.
+       */
+      UINT32 Avx512Vpopcntdq                                       : 1;
+#define CPUID_ECX_AVX512_VPOPCNTDQ_BIT                               14
+#define CPUID_ECX_AVX512_VPOPCNTDQ_FLAG                              0x4000
+#define CPUID_ECX_AVX512_VPOPCNTDQ_MASK                              0x01
+#define CPUID_ECX_AVX512_VPOPCNTDQ(_)                                (((_) >> 14) & 0x01)
+      UINT32 Reserved1                                             : 1;
+
+      /**
+       * [Bit 16] Supports 57-bit linear addresses and five-level paging if 1.
+       */
+      UINT32 La57                                                  : 1;
+#define CPUID_ECX_LA57_BIT                                           16
+#define CPUID_ECX_LA57_FLAG                                          0x10000
+#define CPUID_ECX_LA57_MASK                                          0x01
+#define CPUID_ECX_LA57(_)                                            (((_) >> 16) & 0x01)
 
       /**
        * [Bits 21:17] The value of MAWAU used by the BNDLDX and BNDSTX instructions in 64-bit mode.
@@ -2833,7 +2989,45 @@ typedef struct
 #define CPUID_ECX_RDPID_FLAG                                         0x400000
 #define CPUID_ECX_RDPID_MASK                                         0x01
 #define CPUID_ECX_RDPID(_)                                           (((_) >> 22) & 0x01)
-      UINT32 Reserved2                                             : 7;
+
+      /**
+       * [Bit 23] KL. Supports Key Locker if 1.
+       */
+      UINT32 Kl                                                    : 1;
+#define CPUID_ECX_KL_BIT                                             23
+#define CPUID_ECX_KL_FLAG                                            0x800000
+#define CPUID_ECX_KL_MASK                                            0x01
+#define CPUID_ECX_KL(_)                                              (((_) >> 23) & 0x01)
+      UINT32 Reserved2                                             : 1;
+
+      /**
+       * [Bit 25] Supports cache line demote if 1.
+       */
+      UINT32 Cldemote                                              : 1;
+#define CPUID_ECX_CLDEMOTE_BIT                                       25
+#define CPUID_ECX_CLDEMOTE_FLAG                                      0x2000000
+#define CPUID_ECX_CLDEMOTE_MASK                                      0x01
+#define CPUID_ECX_CLDEMOTE(_)                                        (((_) >> 25) & 0x01)
+      UINT32 Reserved3                                             : 1;
+
+      /**
+       * [Bit 27] Supports MOVDIRI if 1.
+       */
+      UINT32 Movdiri                                               : 1;
+#define CPUID_ECX_MOVDIRI_BIT                                        27
+#define CPUID_ECX_MOVDIRI_FLAG                                       0x8000000
+#define CPUID_ECX_MOVDIRI_MASK                                       0x01
+#define CPUID_ECX_MOVDIRI(_)                                         (((_) >> 27) & 0x01)
+
+      /**
+       * [Bit 28] Supports MOVDIR64B if 1.
+       */
+      UINT32 Movdir64B                                             : 1;
+#define CPUID_ECX_MOVDIR64B_BIT                                      28
+#define CPUID_ECX_MOVDIR64B_FLAG                                     0x10000000
+#define CPUID_ECX_MOVDIR64B_MASK                                     0x01
+#define CPUID_ECX_MOVDIR64B(_)                                       (((_) >> 28) & 0x01)
+      UINT32 Reserved4                                             : 1;
 
       /**
        * [Bit 30] Supports SGX Launch Configuration if 1.
@@ -2843,7 +3037,15 @@ typedef struct
 #define CPUID_ECX_SGX_LC_FLAG                                        0x40000000
 #define CPUID_ECX_SGX_LC_MASK                                        0x01
 #define CPUID_ECX_SGX_LC(_)                                          (((_) >> 30) & 0x01)
-      UINT32 Reserved3                                             : 1;
+
+      /**
+       * [Bit 31] Supports protection keys for supervisor-mode pages if 1.
+       */
+      UINT32 Pks                                                   : 1;
+#define CPUID_ECX_PKS_BIT                                            31
+#define CPUID_ECX_PKS_FLAG                                           0x80000000
+#define CPUID_ECX_PKS_MASK                                           0x01
+#define CPUID_ECX_PKS(_)                                             (((_) >> 31) & 0x01)
     };
 
     UINT32 Flags;
@@ -2853,14 +3055,145 @@ typedef struct
   {
     struct
     {
+      UINT32 Reserved1                                             : 2;
+
       /**
-       * [Bits 31:0] EDX is reserved.
+       * [Bit 2] (Intel(R) Xeon Phi(TM) only.)
        */
-      UINT32 Reserved                                              : 32;
-#define CPUID_EDX_RESERVED_BIT                                       0
-#define CPUID_EDX_RESERVED_FLAG                                      0xFFFFFFFF
-#define CPUID_EDX_RESERVED_MASK                                      0xFFFFFFFF
-#define CPUID_EDX_RESERVED(_)                                        (((_) >> 0) & 0xFFFFFFFF)
+      UINT32 Avx5124Vnniw                                          : 1;
+#define CPUID_EDX_AVX512_4VNNIW_BIT                                  2
+#define CPUID_EDX_AVX512_4VNNIW_FLAG                                 0x04
+#define CPUID_EDX_AVX512_4VNNIW_MASK                                 0x01
+#define CPUID_EDX_AVX512_4VNNIW(_)                                   (((_) >> 2) & 0x01)
+
+      /**
+       * [Bit 3] (Intel(R) Xeon Phi(TM) only.)
+       */
+      UINT32 Avx5124Fmaps                                          : 1;
+#define CPUID_EDX_AVX512_4FMAPS_BIT                                  3
+#define CPUID_EDX_AVX512_4FMAPS_FLAG                                 0x08
+#define CPUID_EDX_AVX512_4FMAPS_MASK                                 0x01
+#define CPUID_EDX_AVX512_4FMAPS(_)                                   (((_) >> 3) & 0x01)
+
+      /**
+       * [Bit 4] Fast Short REP MOV.
+       */
+      UINT32 FastShortRepMov                                       : 1;
+#define CPUID_EDX_FAST_SHORT_REP_MOV_BIT                             4
+#define CPUID_EDX_FAST_SHORT_REP_MOV_FLAG                            0x10
+#define CPUID_EDX_FAST_SHORT_REP_MOV_MASK                            0x01
+#define CPUID_EDX_FAST_SHORT_REP_MOV(_)                              (((_) >> 4) & 0x01)
+      UINT32 Reserved2                                             : 3;
+
+      /**
+       * [Bit 8] AVX512_VP2INTERSECT.
+       */
+      UINT32 Avx512Vp2Intersect                                    : 1;
+#define CPUID_EDX_AVX512_VP2INTERSECT_BIT                            8
+#define CPUID_EDX_AVX512_VP2INTERSECT_FLAG                           0x100
+#define CPUID_EDX_AVX512_VP2INTERSECT_MASK                           0x01
+#define CPUID_EDX_AVX512_VP2INTERSECT(_)                             (((_) >> 8) & 0x01)
+      UINT32 Reserved3                                             : 1;
+
+      /**
+       * [Bit 10] MD_CLEAR supported.
+       */
+      UINT32 MdClear                                               : 1;
+#define CPUID_EDX_MD_CLEAR_BIT                                       10
+#define CPUID_EDX_MD_CLEAR_FLAG                                      0x400
+#define CPUID_EDX_MD_CLEAR_MASK                                      0x01
+#define CPUID_EDX_MD_CLEAR(_)                                        (((_) >> 10) & 0x01)
+      UINT32 Reserved4                                             : 4;
+
+      /**
+       * [Bit 15] If 1, the processor is identified as a hybrid part.
+       */
+      UINT32 Hybrid                                                : 1;
+#define CPUID_EDX_HYBRID_BIT                                         15
+#define CPUID_EDX_HYBRID_FLAG                                        0x8000
+#define CPUID_EDX_HYBRID_MASK                                        0x01
+#define CPUID_EDX_HYBRID(_)                                          (((_) >> 15) & 0x01)
+      UINT32 Reserved5                                             : 2;
+
+      /**
+       * [Bit 18] Supports PCONFIG if 1.
+       */
+      UINT32 Pconfig                                               : 1;
+#define CPUID_EDX_PCONFIG_BIT                                        18
+#define CPUID_EDX_PCONFIG_FLAG                                       0x40000
+#define CPUID_EDX_PCONFIG_MASK                                       0x01
+#define CPUID_EDX_PCONFIG(_)                                         (((_) >> 18) & 0x01)
+      UINT32 Reserved6                                             : 1;
+
+      /**
+       * [Bit 20] Supports CET indirect branch tracking features if 1. Processors that set this bit define bits 5:2 and bits
+       * 63:10 of the IA32_U_CET and IA32_S_CET MSRs.
+       */
+      UINT32 CetIbt                                                : 1;
+#define CPUID_EDX_CET_IBT_BIT                                        20
+#define CPUID_EDX_CET_IBT_FLAG                                       0x100000
+#define CPUID_EDX_CET_IBT_MASK                                       0x01
+#define CPUID_EDX_CET_IBT(_)                                         (((_) >> 20) & 0x01)
+      UINT32 Reserved7                                             : 5;
+
+      /**
+       * [Bit 26] Enumerates support for indirect branch restricted speculation (IBRS) and the indirect branch predictor barrier
+       * (IBPB). Processors that set this bit support the IA32_SPEC_CTRL MSR and the IA32_PRED_CMD MSR. They allow software to
+       * set IA32_SPEC_CTRL[0] (IBRS) and IA32_PRED_CMD[0] (IBPB).
+       */
+      UINT32 IbrsIbpb                                              : 1;
+#define CPUID_EDX_IBRS_IBPB_BIT                                      26
+#define CPUID_EDX_IBRS_IBPB_FLAG                                     0x4000000
+#define CPUID_EDX_IBRS_IBPB_MASK                                     0x01
+#define CPUID_EDX_IBRS_IBPB(_)                                       (((_) >> 26) & 0x01)
+
+      /**
+       * [Bit 27] Enumerates support for single thread indirect branch predictors (STIBP). Processors that set this bit support
+       * the IA32_SPEC_CTRL MSR. They allow software to set IA32_SPEC_CTRL[1] (STIBP).
+       */
+      UINT32 Stibp                                                 : 1;
+#define CPUID_EDX_STIBP_BIT                                          27
+#define CPUID_EDX_STIBP_FLAG                                         0x8000000
+#define CPUID_EDX_STIBP_MASK                                         0x01
+#define CPUID_EDX_STIBP(_)                                           (((_) >> 27) & 0x01)
+
+      /**
+       * [Bit 28] Enumerates support for L1D_FLUSH. Processors that set this bit support the IA32_FLUSH_CMD MSR. They allow
+       * software to set IA32_FLUSH_CMD[0] (L1D_FLUSH).
+       */
+      UINT32 L1DFlush                                              : 1;
+#define CPUID_EDX_L1D_FLUSH_BIT                                      28
+#define CPUID_EDX_L1D_FLUSH_FLAG                                     0x10000000
+#define CPUID_EDX_L1D_FLUSH_MASK                                     0x01
+#define CPUID_EDX_L1D_FLUSH(_)                                       (((_) >> 28) & 0x01)
+
+      /**
+       * [Bit 29] Enumerates support for the IA32_ARCH_CAPABILITIES MSR.
+       */
+      UINT32 Ia32ArchCapabilities                                  : 1;
+#define CPUID_EDX_IA32_ARCH_CAPABILITIES_BIT                         29
+#define CPUID_EDX_IA32_ARCH_CAPABILITIES_FLAG                        0x20000000
+#define CPUID_EDX_IA32_ARCH_CAPABILITIES_MASK                        0x01
+#define CPUID_EDX_IA32_ARCH_CAPABILITIES(_)                          (((_) >> 29) & 0x01)
+
+      /**
+       * [Bit 30] Enumerates support for the IA32_CORE_CAPABILITIES MSR.
+       */
+      UINT32 Ia32CoreCapabilities                                  : 1;
+#define CPUID_EDX_IA32_CORE_CAPABILITIES_BIT                         30
+#define CPUID_EDX_IA32_CORE_CAPABILITIES_FLAG                        0x40000000
+#define CPUID_EDX_IA32_CORE_CAPABILITIES_MASK                        0x01
+#define CPUID_EDX_IA32_CORE_CAPABILITIES(_)                          (((_) >> 30) & 0x01)
+
+      /**
+       * [Bit 31] Enumerates support for Speculative Store Bypass Disable (SSBD). Processors that set this bit support the
+       * IA32_SPEC_CTRL MSR. They allow software to set IA32_SPEC_CTRL[2] (SSBD).
+       */
+      UINT32 Ssbd                                                  : 1;
+#define CPUID_EDX_SSBD_BIT                                           31
+#define CPUID_EDX_SSBD_FLAG                                          0x80000000
+#define CPUID_EDX_SSBD_MASK                                          0x01
+#define CPUID_EDX_SSBD(_)                                            (((_) >> 31) & 0x01)
     };
 
     UINT32 Flags;
@@ -10582,7 +10915,39 @@ typedef union
 #define IA32_VMX_EXIT_CTLS_CONCEAL_VMX_FROM_PT_FLAG                  0x1000000
 #define IA32_VMX_EXIT_CTLS_CONCEAL_VMX_FROM_PT_MASK                  0x01
 #define IA32_VMX_EXIT_CTLS_CONCEAL_VMX_FROM_PT(_)                    (((_) >> 24) & 0x01)
-    UINT64 Reserved6                                               : 39;
+
+    /**
+     * [Bit 25] This control determines whether the IA32_RTIT_CTL MSR is cleared on VM exit.
+     *
+     * @see Vol3C[35(INTEL(R) PROCESSOR TRACE)]
+     */
+    UINT64 ClearIa32RtitCtl                                        : 1;
+#define IA32_VMX_EXIT_CTLS_CLEAR_IA32_RTIT_CTL_BIT                   25
+#define IA32_VMX_EXIT_CTLS_CLEAR_IA32_RTIT_CTL_FLAG                  0x2000000
+#define IA32_VMX_EXIT_CTLS_CLEAR_IA32_RTIT_CTL_MASK                  0x01
+#define IA32_VMX_EXIT_CTLS_CLEAR_IA32_RTIT_CTL(_)                    (((_) >> 25) & 0x01)
+    UINT64 Reserved6                                               : 2;
+
+    /**
+     * [Bit 28] This control determines whether CET-related MSRs and SPP are loaded on VM exit.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 LoadIa32CetState                                        : 1;
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_CET_STATE_BIT                   28
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_CET_STATE_FLAG                  0x10000000
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_CET_STATE_MASK                  0x01
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_CET_STATE(_)                    (((_) >> 28) & 0x01)
+
+    /**
+     * [Bit 29] This control determines whether the IA32_PKRS MSR is loaded on VM exit.
+     */
+    UINT64 LoadIa32Pkrs                                            : 1;
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_PKRS_BIT                        29
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_PKRS_FLAG                       0x20000000
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_PKRS_MASK                       0x01
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_PKRS(_)                         (((_) >> 29) & 0x01)
+    UINT64 Reserved7                                               : 34;
   };
 
   UINT64 Flags;
@@ -10729,7 +11094,17 @@ typedef union
 #define IA32_VMX_ENTRY_CTLS_LOAD_CET_STATE_FLAG                      0x100000
 #define IA32_VMX_ENTRY_CTLS_LOAD_CET_STATE_MASK                      0x01
 #define IA32_VMX_ENTRY_CTLS_LOAD_CET_STATE(_)                        (((_) >> 20) & 0x01)
-    UINT64 Reserved5                                               : 43;
+    UINT64 Reserved5                                               : 1;
+
+    /**
+     * [Bit 22] This control determines whether the IA32_PKRS MSR is loaded on VM entry.
+     */
+    UINT64 LoadIa32Pkrs                                            : 1;
+#define IA32_VMX_ENTRY_CTLS_LOAD_IA32_PKRS_BIT                       22
+#define IA32_VMX_ENTRY_CTLS_LOAD_IA32_PKRS_FLAG                      0x400000
+#define IA32_VMX_ENTRY_CTLS_LOAD_IA32_PKRS_MASK                      0x01
+#define IA32_VMX_ENTRY_CTLS_LOAD_IA32_PKRS(_)                        (((_) >> 22) & 0x01)
+    UINT64 Reserved6                                               : 41;
   };
 
   UINT64 Flags;
@@ -12466,6 +12841,302 @@ typedef union
  * @see Vol3B[18.6.3.4(Debug Store (DS) Mechanism)]
  */
 #define IA32_DS_AREA                                                 0x00000600
+
+/**
+ * Configure User Mode CET
+ *
+ * @remarks - Bits 1:0 are defined if CPUID.(EAX=07H,ECX=0H):ECX.CET_SS[07] = 1. - Bits 5:2 and bits 63:10 are defined if
+ *          CPUID.(EAX=07H,ECX=0H):EDX.CET_IBT[20] = 1.
+ */
+#define IA32_U_CET                                                   0x000006A0
+typedef union
+{
+  struct
+  {
+    /**
+     * [Bit 0] When set to 1, enable shadow stacks at CPL3.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 ShStkEn                                                 : 1;
+#define IA32_U_CET_SH_STK_EN_BIT                                     0
+#define IA32_U_CET_SH_STK_EN_FLAG                                    0x01
+#define IA32_U_CET_SH_STK_EN_MASK                                    0x01
+#define IA32_U_CET_SH_STK_EN(_)                                      (((_) >> 0) & 0x01)
+
+    /**
+     * [Bit 1] When set to 1, enables the WRSSD/WRSSQ instructions.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 WrShstkEn                                               : 1;
+#define IA32_U_CET_WR_SHSTK_EN_BIT                                   1
+#define IA32_U_CET_WR_SHSTK_EN_FLAG                                  0x02
+#define IA32_U_CET_WR_SHSTK_EN_MASK                                  0x01
+#define IA32_U_CET_WR_SHSTK_EN(_)                                    (((_) >> 1) & 0x01)
+
+    /**
+     * [Bit 2] When set to 1, enables indirect branch tracking
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 EndbrEn                                                 : 1;
+#define IA32_U_CET_ENDBR_EN_BIT                                      2
+#define IA32_U_CET_ENDBR_EN_FLAG                                     0x04
+#define IA32_U_CET_ENDBR_EN_MASK                                     0x01
+#define IA32_U_CET_ENDBR_EN(_)                                       (((_) >> 2) & 0x01)
+
+    /**
+     * [Bit 3] Enable legacy compatibility treatment for indirect branch tracking.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 LegIwEn                                                 : 1;
+#define IA32_U_CET_LEG_IW_EN_BIT                                     3
+#define IA32_U_CET_LEG_IW_EN_FLAG                                    0x08
+#define IA32_U_CET_LEG_IW_EN_MASK                                    0x01
+#define IA32_U_CET_LEG_IW_EN(_)                                      (((_) >> 3) & 0x01)
+
+    /**
+     * [Bit 4] When set to 1, enables use of no-track prefix for indirect branch tracking.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 NoTrackEn                                               : 1;
+#define IA32_U_CET_NO_TRACK_EN_BIT                                   4
+#define IA32_U_CET_NO_TRACK_EN_FLAG                                  0x10
+#define IA32_U_CET_NO_TRACK_EN_MASK                                  0x01
+#define IA32_U_CET_NO_TRACK_EN(_)                                    (((_) >> 4) & 0x01)
+
+    /**
+     * [Bit 5] When set to 1, disables suppression of CET indirect branch tracking on legacy compatibility.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 SuppressDis                                             : 1;
+#define IA32_U_CET_SUPPRESS_DIS_BIT                                  5
+#define IA32_U_CET_SUPPRESS_DIS_FLAG                                 0x20
+#define IA32_U_CET_SUPPRESS_DIS_MASK                                 0x01
+#define IA32_U_CET_SUPPRESS_DIS(_)                                   (((_) >> 5) & 0x01)
+    UINT64 Reserved1                                               : 4;
+
+    /**
+     * [Bit 10] When set to 1, indirect branch tracking is suppressed. This bit can be written to 1 only if TRACKER is written
+     * as IDLE.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 Suppress                                                : 1;
+#define IA32_U_CET_SUPPRESS_BIT                                      10
+#define IA32_U_CET_SUPPRESS_FLAG                                     0x400
+#define IA32_U_CET_SUPPRESS_MASK                                     0x01
+#define IA32_U_CET_SUPPRESS(_)                                       (((_) >> 10) & 0x01)
+
+    /**
+     * [Bit 11] Value of the indirect branch tracking state machine. Values: IDLE (0), WAIT_FOR_ENDBRANCH(1).
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 Tracker                                                 : 1;
+#define IA32_U_CET_TRACKER_BIT                                       11
+#define IA32_U_CET_TRACKER_FLAG                                      0x800
+#define IA32_U_CET_TRACKER_MASK                                      0x01
+#define IA32_U_CET_TRACKER(_)                                        (((_) >> 11) & 0x01)
+
+    /**
+     * [Bits 63:12] Linear address bits 63:12 of a legacy code page bitmap used for legacy compatibility when indirect branch
+     * tracking is enabled. If the processor does not support Intel 64 architecture, these fields have only 32 bits; bits 63:32
+     * of the MSRs are reserved. On processors that support Intel 64 architecture this value cannot represent a non-canonical
+     * address. In protected mode, only 31:0 are loaded. The linear address written must be aligned to 8 bytes and bits 2:0
+     * must be 0 (hardware requires bits 1:0 to be 0).
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 EbLegBitmapBase                                         : 52;
+#define IA32_U_CET_EB_LEG_BITMAP_BASE_BIT                            12
+#define IA32_U_CET_EB_LEG_BITMAP_BASE_FLAG                           0xFFFFFFFFFFFFF000
+#define IA32_U_CET_EB_LEG_BITMAP_BASE_MASK                           0xFFFFFFFFFFFFF
+#define IA32_U_CET_EB_LEG_BITMAP_BASE(_)                             (((_) >> 12) & 0xFFFFFFFFFFFFF)
+  };
+
+  UINT64 Flags;
+} IA32_U_CET_REGISTER;
+
+
+/**
+ * Configure Supervisor Mode CET
+ *
+ * @remarks - Bits 1:0 are defined if CPUID.(EAX=07H,ECX=0H):ECX.CET_SS[07] = 1. - Bits 5:2 and bits 63:10 are defined if
+ *          CPUID.(EAX=07H,ECX=0H):EDX.CET_IBT[20] = 1.
+ */
+#define IA32_S_CET                                                   0x000006A2
+typedef union
+{
+  struct
+  {
+    /**
+     * [Bit 0] When set to 1, enable shadow stacks at CPL3.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 ShStkEn                                                 : 1;
+#define IA32_S_CET_SH_STK_EN_BIT                                     0
+#define IA32_S_CET_SH_STK_EN_FLAG                                    0x01
+#define IA32_S_CET_SH_STK_EN_MASK                                    0x01
+#define IA32_S_CET_SH_STK_EN(_)                                      (((_) >> 0) & 0x01)
+
+    /**
+     * [Bit 1] When set to 1, enables the WRSSD/WRSSQ instructions.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 WrShstkEn                                               : 1;
+#define IA32_S_CET_WR_SHSTK_EN_BIT                                   1
+#define IA32_S_CET_WR_SHSTK_EN_FLAG                                  0x02
+#define IA32_S_CET_WR_SHSTK_EN_MASK                                  0x01
+#define IA32_S_CET_WR_SHSTK_EN(_)                                    (((_) >> 1) & 0x01)
+
+    /**
+     * [Bit 2] When set to 1, enables indirect branch tracking
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 EndbrEn                                                 : 1;
+#define IA32_S_CET_ENDBR_EN_BIT                                      2
+#define IA32_S_CET_ENDBR_EN_FLAG                                     0x04
+#define IA32_S_CET_ENDBR_EN_MASK                                     0x01
+#define IA32_S_CET_ENDBR_EN(_)                                       (((_) >> 2) & 0x01)
+
+    /**
+     * [Bit 3] Enable legacy compatibility treatment for indirect branch tracking.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 LegIwEn                                                 : 1;
+#define IA32_S_CET_LEG_IW_EN_BIT                                     3
+#define IA32_S_CET_LEG_IW_EN_FLAG                                    0x08
+#define IA32_S_CET_LEG_IW_EN_MASK                                    0x01
+#define IA32_S_CET_LEG_IW_EN(_)                                      (((_) >> 3) & 0x01)
+
+    /**
+     * [Bit 4] When set to 1, enables use of no-track prefix for indirect branch tracking.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 NoTrackEn                                               : 1;
+#define IA32_S_CET_NO_TRACK_EN_BIT                                   4
+#define IA32_S_CET_NO_TRACK_EN_FLAG                                  0x10
+#define IA32_S_CET_NO_TRACK_EN_MASK                                  0x01
+#define IA32_S_CET_NO_TRACK_EN(_)                                    (((_) >> 4) & 0x01)
+
+    /**
+     * [Bit 5] When set to 1, disables suppression of CET indirect branch tracking on legacy compatibility.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 SuppressDis                                             : 1;
+#define IA32_S_CET_SUPPRESS_DIS_BIT                                  5
+#define IA32_S_CET_SUPPRESS_DIS_FLAG                                 0x20
+#define IA32_S_CET_SUPPRESS_DIS_MASK                                 0x01
+#define IA32_S_CET_SUPPRESS_DIS(_)                                   (((_) >> 5) & 0x01)
+    UINT64 Reserved1                                               : 4;
+
+    /**
+     * [Bit 10] When set to 1, indirect branch tracking is suppressed. This bit can be written to 1 only if TRACKER is written
+     * as IDLE.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 Suppress                                                : 1;
+#define IA32_S_CET_SUPPRESS_BIT                                      10
+#define IA32_S_CET_SUPPRESS_FLAG                                     0x400
+#define IA32_S_CET_SUPPRESS_MASK                                     0x01
+#define IA32_S_CET_SUPPRESS(_)                                       (((_) >> 10) & 0x01)
+
+    /**
+     * [Bit 11] Value of the indirect branch tracking state machine. Values: IDLE (0), WAIT_FOR_ENDBRANCH(1).
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 Tracker                                                 : 1;
+#define IA32_S_CET_TRACKER_BIT                                       11
+#define IA32_S_CET_TRACKER_FLAG                                      0x800
+#define IA32_S_CET_TRACKER_MASK                                      0x01
+#define IA32_S_CET_TRACKER(_)                                        (((_) >> 11) & 0x01)
+
+    /**
+     * [Bits 63:12] Linear address bits 63:12 of a legacy code page bitmap used for legacy compatibility when indirect branch
+     * tracking is enabled. If the processor does not support Intel 64 architecture, these fields have only 32 bits; bits 63:32
+     * of the MSRs are reserved. On processors that support Intel 64 architecture this value cannot represent a non-canonical
+     * address. In protected mode, only 31:0 are loaded. The linear address written must be aligned to 8 bytes and bits 2:0
+     * must be 0 (hardware requires bits 1:0 to be 0).
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    UINT64 EbLegBitmapBase                                         : 52;
+#define IA32_S_CET_EB_LEG_BITMAP_BASE_BIT                            12
+#define IA32_S_CET_EB_LEG_BITMAP_BASE_FLAG                           0xFFFFFFFFFFFFF000
+#define IA32_S_CET_EB_LEG_BITMAP_BASE_MASK                           0xFFFFFFFFFFFFF
+#define IA32_S_CET_EB_LEG_BITMAP_BASE(_)                             (((_) >> 12) & 0xFFFFFFFFFFFFF)
+  };
+
+  UINT64 Flags;
+} IA32_S_CET_REGISTER;
+
+
+/**
+ * Linear address to be loaded into SSP on transition to privilege level 0.
+ * If the processor does not support Intel 64 architecture, these fields have only 32 bits; bits 63:32 of the MSRs are
+ * reserved. On processors that support Intel 64 architecture this value cannot represent a non-canonical address. In
+ * protected mode, only 31:0 are loaded. The linear address written must be aligned to 8 bytes and bits 2:0 must be 0
+ * (hardware requires bits 1:0 to be 0).
+ *
+ * @remarks If CPUID.(EAX=07H, ECX=0H):ECX.CET_SS[07] = 1
+ */
+#define IA32_PL0_SSP                                                 0x000006A4
+
+/**
+ * Linear address to be loaded into SSP on transition to privilege level 1.
+ * If the processor does not support Intel 64 architecture, these fields have only 32 bits; bits 63:32 of the MSRs are
+ * reserved. On processors that support Intel 64 architecture this value cannot represent a non-canonical address. In
+ * protected mode, only 31:0 are loaded. The linear address written must be aligned to 8 bytes and bits 2:0 must be 0
+ * (hardware requires bits 1:0 to be 0).
+ *
+ * @remarks If CPUID.(EAX=07H, ECX=0H):ECX.CET_SS[07] = 1
+ */
+#define IA32_PL1_SSP                                                 0x000006A5
+
+/**
+ * Linear address to be loaded into SSP on transition to privilege level 2.
+ * If the processor does not support Intel 64 architecture, these fields have only 32 bits; bits 63:32 of the MSRs are
+ * reserved. On processors that support Intel 64 architecture this value cannot represent a non-canonical address. In
+ * protected mode, only 31:0 are loaded. The linear address written must be aligned to 8 bytes and bits 2:0 must be 0
+ * (hardware requires bits 1:0 to be 0).
+ *
+ * @remarks If CPUID.(EAX=07H, ECX=0H):ECX.CET_SS[07] = 1
+ */
+#define IA32_PL2_SSP                                                 0x000006A6
+
+/**
+ * Linear address to be loaded into SSP on transition to privilege level 3.
+ * If the processor does not support Intel 64 architecture, these fields have only 32 bits; bits 63:32 of the MSRs are
+ * reserved. On processors that support Intel 64 architecture this value cannot represent a non-canonical address. In
+ * protected mode, only 31:0 are loaded. The linear address written must be aligned to 8 bytes and bits 2:0 must be 0
+ * (hardware requires bits 1:0 to be 0).
+ *
+ * @remarks If CPUID.(EAX=07H, ECX=0H):ECX.CET_SS[07] = 1
+ */
+#define IA32_PL3_SSP                                                 0x000006A7
+
+/**
+ * Linear address of a table of seven shadow stack pointers that are selected in IA-32e mode using the IST index (when not
+ * 0) from the interrupt gate descriptor.
+ * This MSR is not present on processors that do not support Intel 64 architecture. This field cannot represent a
+ * non-canonical address.
+ *
+ * @remarks If CPUID.(EAX=07H, ECX=0H):ECX.CET_SS[07] = 1
+ */
+#define IA32_INTERRUPT_SSP_TABLE_ADDR                                0x000006A8
 
 /**
  * TSC Target of Local APIC's TSC Deadline Mode.
@@ -18268,19 +18939,19 @@ typedef union
      * [Bit 0] Read access; indicates whether reads are allowed from the 512-GByte region controlled by this entry.
      */
     UINT64 ReadAccess                                              : 1;
-#define EPT_PML4_READ_ACCESS_BIT                                     0
-#define EPT_PML4_READ_ACCESS_FLAG                                    0x01
-#define EPT_PML4_READ_ACCESS_MASK                                    0x01
-#define EPT_PML4_READ_ACCESS(_)                                      (((_) >> 0) & 0x01)
+#define EPT_PML4E_READ_ACCESS_BIT                                    0
+#define EPT_PML4E_READ_ACCESS_FLAG                                   0x01
+#define EPT_PML4E_READ_ACCESS_MASK                                   0x01
+#define EPT_PML4E_READ_ACCESS(_)                                     (((_) >> 0) & 0x01)
 
     /**
      * [Bit 1] Write access; indicates whether writes are allowed from the 512-GByte region controlled by this entry.
      */
     UINT64 WriteAccess                                             : 1;
-#define EPT_PML4_WRITE_ACCESS_BIT                                    1
-#define EPT_PML4_WRITE_ACCESS_FLAG                                   0x02
-#define EPT_PML4_WRITE_ACCESS_MASK                                   0x01
-#define EPT_PML4_WRITE_ACCESS(_)                                     (((_) >> 1) & 0x01)
+#define EPT_PML4E_WRITE_ACCESS_BIT                                   1
+#define EPT_PML4E_WRITE_ACCESS_FLAG                                  0x02
+#define EPT_PML4E_WRITE_ACCESS_MASK                                  0x01
+#define EPT_PML4E_WRITE_ACCESS(_)                                    (((_) >> 1) & 0x01)
 
     /**
      * [Bit 2] If the "mode-based execute control for EPT" VM-execution control is 0, execute access; indicates whether
@@ -18289,10 +18960,10 @@ typedef union
      * allowed from supervisor-mode linear addresses in the 512-GByte region controlled by this entry.
      */
     UINT64 ExecuteAccess                                           : 1;
-#define EPT_PML4_EXECUTE_ACCESS_BIT                                  2
-#define EPT_PML4_EXECUTE_ACCESS_FLAG                                 0x04
-#define EPT_PML4_EXECUTE_ACCESS_MASK                                 0x01
-#define EPT_PML4_EXECUTE_ACCESS(_)                                   (((_) >> 2) & 0x01)
+#define EPT_PML4E_EXECUTE_ACCESS_BIT                                 2
+#define EPT_PML4E_EXECUTE_ACCESS_FLAG                                0x04
+#define EPT_PML4E_EXECUTE_ACCESS_MASK                                0x01
+#define EPT_PML4E_EXECUTE_ACCESS(_)                                  (((_) >> 2) & 0x01)
     UINT64 Reserved1                                               : 5;
 
     /**
@@ -18302,10 +18973,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     UINT64 Accessed                                                : 1;
-#define EPT_PML4_ACCESSED_BIT                                        8
-#define EPT_PML4_ACCESSED_FLAG                                       0x100
-#define EPT_PML4_ACCESSED_MASK                                       0x01
-#define EPT_PML4_ACCESSED(_)                                         (((_) >> 8) & 0x01)
+#define EPT_PML4E_ACCESSED_BIT                                       8
+#define EPT_PML4E_ACCESSED_FLAG                                      0x100
+#define EPT_PML4E_ACCESSED_MASK                                      0x01
+#define EPT_PML4E_ACCESSED(_)                                        (((_) >> 8) & 0x01)
     UINT64 Reserved2                                               : 1;
 
     /**
@@ -18314,25 +18985,25 @@ typedef union
      * controlled by this entry. If that control is 0, this bit is ignored.
      */
     UINT64 UserModeExecute                                         : 1;
-#define EPT_PML4_USER_MODE_EXECUTE_BIT                               10
-#define EPT_PML4_USER_MODE_EXECUTE_FLAG                              0x400
-#define EPT_PML4_USER_MODE_EXECUTE_MASK                              0x01
-#define EPT_PML4_USER_MODE_EXECUTE(_)                                (((_) >> 10) & 0x01)
+#define EPT_PML4E_USER_MODE_EXECUTE_BIT                              10
+#define EPT_PML4E_USER_MODE_EXECUTE_FLAG                             0x400
+#define EPT_PML4E_USER_MODE_EXECUTE_MASK                             0x01
+#define EPT_PML4E_USER_MODE_EXECUTE(_)                               (((_) >> 10) & 0x01)
     UINT64 Reserved3                                               : 1;
 
     /**
      * [Bits 47:12] Physical address of 4-KByte aligned EPT page-directory-pointer table referenced by this entry.
      */
     UINT64 PageFrameNumber                                         : 36;
-#define EPT_PML4_PAGE_FRAME_NUMBER_BIT                               12
-#define EPT_PML4_PAGE_FRAME_NUMBER_FLAG                              0xFFFFFFFFF000
-#define EPT_PML4_PAGE_FRAME_NUMBER_MASK                              0xFFFFFFFFF
-#define EPT_PML4_PAGE_FRAME_NUMBER(_)                                (((_) >> 12) & 0xFFFFFFFFF)
+#define EPT_PML4E_PAGE_FRAME_NUMBER_BIT                              12
+#define EPT_PML4E_PAGE_FRAME_NUMBER_FLAG                             0xFFFFFFFFF000
+#define EPT_PML4E_PAGE_FRAME_NUMBER_MASK                             0xFFFFFFFFF
+#define EPT_PML4E_PAGE_FRAME_NUMBER(_)                               (((_) >> 12) & 0xFFFFFFFFF)
     UINT64 Reserved4                                               : 16;
   };
 
   UINT64 Flags;
-} EPT_PML4;
+} EPT_PML4E;
 
 /**
  * @brief Format of an EPT Page-Directory-Pointer-Table Entry (PDPTE) that Maps a 1-GByte Page
@@ -18345,19 +19016,19 @@ typedef union
      * [Bit 0] Read access; indicates whether reads are allowed from the 1-GByte page referenced by this entry.
      */
     UINT64 ReadAccess                                              : 1;
-#define EPDPTE_1GB_READ_ACCESS_BIT                                   0
-#define EPDPTE_1GB_READ_ACCESS_FLAG                                  0x01
-#define EPDPTE_1GB_READ_ACCESS_MASK                                  0x01
-#define EPDPTE_1GB_READ_ACCESS(_)                                    (((_) >> 0) & 0x01)
+#define EPT_PDPTE_1GB_READ_ACCESS_BIT                                0
+#define EPT_PDPTE_1GB_READ_ACCESS_FLAG                               0x01
+#define EPT_PDPTE_1GB_READ_ACCESS_MASK                               0x01
+#define EPT_PDPTE_1GB_READ_ACCESS(_)                                 (((_) >> 0) & 0x01)
 
     /**
      * [Bit 1] Write access; indicates whether writes are allowed from the 1-GByte page referenced by this entry.
      */
     UINT64 WriteAccess                                             : 1;
-#define EPDPTE_1GB_WRITE_ACCESS_BIT                                  1
-#define EPDPTE_1GB_WRITE_ACCESS_FLAG                                 0x02
-#define EPDPTE_1GB_WRITE_ACCESS_MASK                                 0x01
-#define EPDPTE_1GB_WRITE_ACCESS(_)                                   (((_) >> 1) & 0x01)
+#define EPT_PDPTE_1GB_WRITE_ACCESS_BIT                               1
+#define EPT_PDPTE_1GB_WRITE_ACCESS_FLAG                              0x02
+#define EPT_PDPTE_1GB_WRITE_ACCESS_MASK                              0x01
+#define EPT_PDPTE_1GB_WRITE_ACCESS(_)                                (((_) >> 1) & 0x01)
 
     /**
      * [Bit 2] If the "mode-based execute control for EPT" VM-execution control is 0, execute access; indicates whether
@@ -18366,10 +19037,10 @@ typedef union
      * allowed from supervisor-mode linear addresses in the 1-GByte page controlled by this entry.
      */
     UINT64 ExecuteAccess                                           : 1;
-#define EPDPTE_1GB_EXECUTE_ACCESS_BIT                                2
-#define EPDPTE_1GB_EXECUTE_ACCESS_FLAG                               0x04
-#define EPDPTE_1GB_EXECUTE_ACCESS_MASK                               0x01
-#define EPDPTE_1GB_EXECUTE_ACCESS(_)                                 (((_) >> 2) & 0x01)
+#define EPT_PDPTE_1GB_EXECUTE_ACCESS_BIT                             2
+#define EPT_PDPTE_1GB_EXECUTE_ACCESS_FLAG                            0x04
+#define EPT_PDPTE_1GB_EXECUTE_ACCESS_MASK                            0x01
+#define EPT_PDPTE_1GB_EXECUTE_ACCESS(_)                              (((_) >> 2) & 0x01)
 
     /**
      * [Bits 5:3] EPT memory type for this 1-GByte page.
@@ -18377,10 +19048,10 @@ typedef union
      * @see Vol3C[28.2.6(EPT and memory Typing)]
      */
     UINT64 MemoryType                                              : 3;
-#define EPDPTE_1GB_MEMORY_TYPE_BIT                                   3
-#define EPDPTE_1GB_MEMORY_TYPE_FLAG                                  0x38
-#define EPDPTE_1GB_MEMORY_TYPE_MASK                                  0x07
-#define EPDPTE_1GB_MEMORY_TYPE(_)                                    (((_) >> 3) & 0x07)
+#define EPT_PDPTE_1GB_MEMORY_TYPE_BIT                                3
+#define EPT_PDPTE_1GB_MEMORY_TYPE_FLAG                               0x38
+#define EPT_PDPTE_1GB_MEMORY_TYPE_MASK                               0x07
+#define EPT_PDPTE_1GB_MEMORY_TYPE(_)                                 (((_) >> 3) & 0x07)
 
     /**
      * [Bit 6] Ignore PAT memory type for this 1-GByte page.
@@ -18388,19 +19059,19 @@ typedef union
      * @see Vol3C[28.2.6(EPT and memory Typing)]
      */
     UINT64 IgnorePat                                               : 1;
-#define EPDPTE_1GB_IGNORE_PAT_BIT                                    6
-#define EPDPTE_1GB_IGNORE_PAT_FLAG                                   0x40
-#define EPDPTE_1GB_IGNORE_PAT_MASK                                   0x01
-#define EPDPTE_1GB_IGNORE_PAT(_)                                     (((_) >> 6) & 0x01)
+#define EPT_PDPTE_1GB_IGNORE_PAT_BIT                                 6
+#define EPT_PDPTE_1GB_IGNORE_PAT_FLAG                                0x40
+#define EPT_PDPTE_1GB_IGNORE_PAT_MASK                                0x01
+#define EPT_PDPTE_1GB_IGNORE_PAT(_)                                  (((_) >> 6) & 0x01)
 
     /**
      * [Bit 7] Must be 1 (otherwise, this entry references an EPT page directory).
      */
     UINT64 LargePage                                               : 1;
-#define EPDPTE_1GB_LARGE_PAGE_BIT                                    7
-#define EPDPTE_1GB_LARGE_PAGE_FLAG                                   0x80
-#define EPDPTE_1GB_LARGE_PAGE_MASK                                   0x01
-#define EPDPTE_1GB_LARGE_PAGE(_)                                     (((_) >> 7) & 0x01)
+#define EPT_PDPTE_1GB_LARGE_PAGE_BIT                                 7
+#define EPT_PDPTE_1GB_LARGE_PAGE_FLAG                                0x80
+#define EPT_PDPTE_1GB_LARGE_PAGE_MASK                                0x01
+#define EPT_PDPTE_1GB_LARGE_PAGE(_)                                  (((_) >> 7) & 0x01)
 
     /**
      * [Bit 8] If bit 6 of EPTP is 1, accessed flag for EPT; indicates whether software has accessed the 1-GByte page
@@ -18409,10 +19080,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     UINT64 Accessed                                                : 1;
-#define EPDPTE_1GB_ACCESSED_BIT                                      8
-#define EPDPTE_1GB_ACCESSED_FLAG                                     0x100
-#define EPDPTE_1GB_ACCESSED_MASK                                     0x01
-#define EPDPTE_1GB_ACCESSED(_)                                       (((_) >> 8) & 0x01)
+#define EPT_PDPTE_1GB_ACCESSED_BIT                                   8
+#define EPT_PDPTE_1GB_ACCESSED_FLAG                                  0x100
+#define EPT_PDPTE_1GB_ACCESSED_MASK                                  0x01
+#define EPT_PDPTE_1GB_ACCESSED(_)                                    (((_) >> 8) & 0x01)
 
     /**
      * [Bit 9] If bit 6 of EPTP is 1, dirty flag for EPT; indicates whether software has written to the 1-GByte page referenced
@@ -18421,10 +19092,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     UINT64 Dirty                                                   : 1;
-#define EPDPTE_1GB_DIRTY_BIT                                         9
-#define EPDPTE_1GB_DIRTY_FLAG                                        0x200
-#define EPDPTE_1GB_DIRTY_MASK                                        0x01
-#define EPDPTE_1GB_DIRTY(_)                                          (((_) >> 9) & 0x01)
+#define EPT_PDPTE_1GB_DIRTY_BIT                                      9
+#define EPT_PDPTE_1GB_DIRTY_FLAG                                     0x200
+#define EPT_PDPTE_1GB_DIRTY_MASK                                     0x01
+#define EPT_PDPTE_1GB_DIRTY(_)                                       (((_) >> 9) & 0x01)
 
     /**
      * [Bit 10] Execute access for user-mode linear addresses. If the "mode-based execute control for EPT" VM-execution control
@@ -18432,20 +19103,20 @@ typedef union
      * by this entry. If that control is 0, this bit is ignored.
      */
     UINT64 UserModeExecute                                         : 1;
-#define EPDPTE_1GB_USER_MODE_EXECUTE_BIT                             10
-#define EPDPTE_1GB_USER_MODE_EXECUTE_FLAG                            0x400
-#define EPDPTE_1GB_USER_MODE_EXECUTE_MASK                            0x01
-#define EPDPTE_1GB_USER_MODE_EXECUTE(_)                              (((_) >> 10) & 0x01)
+#define EPT_PDPTE_1GB_USER_MODE_EXECUTE_BIT                          10
+#define EPT_PDPTE_1GB_USER_MODE_EXECUTE_FLAG                         0x400
+#define EPT_PDPTE_1GB_USER_MODE_EXECUTE_MASK                         0x01
+#define EPT_PDPTE_1GB_USER_MODE_EXECUTE(_)                           (((_) >> 10) & 0x01)
     UINT64 Reserved1                                               : 19;
 
     /**
      * [Bits 47:30] Physical address of 4-KByte aligned EPT page-directory-pointer table referenced by this entry.
      */
     UINT64 PageFrameNumber                                         : 18;
-#define EPDPTE_1GB_PAGE_FRAME_NUMBER_BIT                             30
-#define EPDPTE_1GB_PAGE_FRAME_NUMBER_FLAG                            0xFFFFC0000000
-#define EPDPTE_1GB_PAGE_FRAME_NUMBER_MASK                            0x3FFFF
-#define EPDPTE_1GB_PAGE_FRAME_NUMBER(_)                              (((_) >> 30) & 0x3FFFF)
+#define EPT_PDPTE_1GB_PAGE_FRAME_NUMBER_BIT                          30
+#define EPT_PDPTE_1GB_PAGE_FRAME_NUMBER_FLAG                         0xFFFFC0000000
+#define EPT_PDPTE_1GB_PAGE_FRAME_NUMBER_MASK                         0x3FFFF
+#define EPT_PDPTE_1GB_PAGE_FRAME_NUMBER(_)                           (((_) >> 30) & 0x3FFFF)
     UINT64 Reserved2                                               : 15;
 
     /**
@@ -18456,14 +19127,14 @@ typedef union
      * @see Vol3C[25.5.6.1(Convertible EPT Violations)]
      */
     UINT64 SuppressVe                                              : 1;
-#define EPDPTE_1GB_SUPPRESS_VE_BIT                                   63
-#define EPDPTE_1GB_SUPPRESS_VE_FLAG                                  0x8000000000000000
-#define EPDPTE_1GB_SUPPRESS_VE_MASK                                  0x01
-#define EPDPTE_1GB_SUPPRESS_VE(_)                                    (((_) >> 63) & 0x01)
+#define EPT_PDPTE_1GB_SUPPRESS_VE_BIT                                63
+#define EPT_PDPTE_1GB_SUPPRESS_VE_FLAG                               0x8000000000000000
+#define EPT_PDPTE_1GB_SUPPRESS_VE_MASK                               0x01
+#define EPT_PDPTE_1GB_SUPPRESS_VE(_)                                 (((_) >> 63) & 0x01)
   };
 
   UINT64 Flags;
-} EPDPTE_1GB;
+} EPT_PDPTE_1GB;
 
 /**
  * @brief Format of an EPT Page-Directory-Pointer-Table Entry (PDPTE) that References an EPT Page Directory
@@ -18476,19 +19147,19 @@ typedef union
      * [Bit 0] Read access; indicates whether reads are allowed from the 1-GByte region controlled by this entry.
      */
     UINT64 ReadAccess                                              : 1;
-#define EPDPTE_READ_ACCESS_BIT                                       0
-#define EPDPTE_READ_ACCESS_FLAG                                      0x01
-#define EPDPTE_READ_ACCESS_MASK                                      0x01
-#define EPDPTE_READ_ACCESS(_)                                        (((_) >> 0) & 0x01)
+#define EPT_PDPTE_READ_ACCESS_BIT                                    0
+#define EPT_PDPTE_READ_ACCESS_FLAG                                   0x01
+#define EPT_PDPTE_READ_ACCESS_MASK                                   0x01
+#define EPT_PDPTE_READ_ACCESS(_)                                     (((_) >> 0) & 0x01)
 
     /**
      * [Bit 1] Write access; indicates whether writes are allowed from the 1-GByte region controlled by this entry.
      */
     UINT64 WriteAccess                                             : 1;
-#define EPDPTE_WRITE_ACCESS_BIT                                      1
-#define EPDPTE_WRITE_ACCESS_FLAG                                     0x02
-#define EPDPTE_WRITE_ACCESS_MASK                                     0x01
-#define EPDPTE_WRITE_ACCESS(_)                                       (((_) >> 1) & 0x01)
+#define EPT_PDPTE_WRITE_ACCESS_BIT                                   1
+#define EPT_PDPTE_WRITE_ACCESS_FLAG                                  0x02
+#define EPT_PDPTE_WRITE_ACCESS_MASK                                  0x01
+#define EPT_PDPTE_WRITE_ACCESS(_)                                    (((_) >> 1) & 0x01)
 
     /**
      * [Bit 2] If the "mode-based execute control for EPT" VM-execution control is 0, execute access; indicates whether
@@ -18497,10 +19168,10 @@ typedef union
      * allowed from supervisor-mode linear addresses in the 1-GByte region controlled by this entry.
      */
     UINT64 ExecuteAccess                                           : 1;
-#define EPDPTE_EXECUTE_ACCESS_BIT                                    2
-#define EPDPTE_EXECUTE_ACCESS_FLAG                                   0x04
-#define EPDPTE_EXECUTE_ACCESS_MASK                                   0x01
-#define EPDPTE_EXECUTE_ACCESS(_)                                     (((_) >> 2) & 0x01)
+#define EPT_PDPTE_EXECUTE_ACCESS_BIT                                 2
+#define EPT_PDPTE_EXECUTE_ACCESS_FLAG                                0x04
+#define EPT_PDPTE_EXECUTE_ACCESS_MASK                                0x01
+#define EPT_PDPTE_EXECUTE_ACCESS(_)                                  (((_) >> 2) & 0x01)
     UINT64 Reserved1                                               : 5;
 
     /**
@@ -18510,10 +19181,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     UINT64 Accessed                                                : 1;
-#define EPDPTE_ACCESSED_BIT                                          8
-#define EPDPTE_ACCESSED_FLAG                                         0x100
-#define EPDPTE_ACCESSED_MASK                                         0x01
-#define EPDPTE_ACCESSED(_)                                           (((_) >> 8) & 0x01)
+#define EPT_PDPTE_ACCESSED_BIT                                       8
+#define EPT_PDPTE_ACCESSED_FLAG                                      0x100
+#define EPT_PDPTE_ACCESSED_MASK                                      0x01
+#define EPT_PDPTE_ACCESSED(_)                                        (((_) >> 8) & 0x01)
     UINT64 Reserved2                                               : 1;
 
     /**
@@ -18522,25 +19193,25 @@ typedef union
      * by this entry. If that control is 0, this bit is ignored.
      */
     UINT64 UserModeExecute                                         : 1;
-#define EPDPTE_USER_MODE_EXECUTE_BIT                                 10
-#define EPDPTE_USER_MODE_EXECUTE_FLAG                                0x400
-#define EPDPTE_USER_MODE_EXECUTE_MASK                                0x01
-#define EPDPTE_USER_MODE_EXECUTE(_)                                  (((_) >> 10) & 0x01)
+#define EPT_PDPTE_USER_MODE_EXECUTE_BIT                              10
+#define EPT_PDPTE_USER_MODE_EXECUTE_FLAG                             0x400
+#define EPT_PDPTE_USER_MODE_EXECUTE_MASK                             0x01
+#define EPT_PDPTE_USER_MODE_EXECUTE(_)                               (((_) >> 10) & 0x01)
     UINT64 Reserved3                                               : 1;
 
     /**
      * [Bits 47:12] Physical address of 4-KByte aligned EPT page-directory-pointer table referenced by this entry.
      */
     UINT64 PageFrameNumber                                         : 36;
-#define EPDPTE_PAGE_FRAME_NUMBER_BIT                                 12
-#define EPDPTE_PAGE_FRAME_NUMBER_FLAG                                0xFFFFFFFFF000
-#define EPDPTE_PAGE_FRAME_NUMBER_MASK                                0xFFFFFFFFF
-#define EPDPTE_PAGE_FRAME_NUMBER(_)                                  (((_) >> 12) & 0xFFFFFFFFF)
+#define EPT_PDPTE_PAGE_FRAME_NUMBER_BIT                              12
+#define EPT_PDPTE_PAGE_FRAME_NUMBER_FLAG                             0xFFFFFFFFF000
+#define EPT_PDPTE_PAGE_FRAME_NUMBER_MASK                             0xFFFFFFFFF
+#define EPT_PDPTE_PAGE_FRAME_NUMBER(_)                               (((_) >> 12) & 0xFFFFFFFFF)
     UINT64 Reserved4                                               : 16;
   };
 
   UINT64 Flags;
-} EPDPTE;
+} EPT_PDPTE;
 
 /**
  * @brief Format of an EPT Page-Directory Entry (PDE) that Maps a 2-MByte Page
@@ -18553,19 +19224,19 @@ typedef union
      * [Bit 0] Read access; indicates whether reads are allowed from the 2-MByte page referenced by this entry.
      */
     UINT64 ReadAccess                                              : 1;
-#define EPDE_2MB_READ_ACCESS_BIT                                     0
-#define EPDE_2MB_READ_ACCESS_FLAG                                    0x01
-#define EPDE_2MB_READ_ACCESS_MASK                                    0x01
-#define EPDE_2MB_READ_ACCESS(_)                                      (((_) >> 0) & 0x01)
+#define EPT_PDE_2MB_READ_ACCESS_BIT                                  0
+#define EPT_PDE_2MB_READ_ACCESS_FLAG                                 0x01
+#define EPT_PDE_2MB_READ_ACCESS_MASK                                 0x01
+#define EPT_PDE_2MB_READ_ACCESS(_)                                   (((_) >> 0) & 0x01)
 
     /**
      * [Bit 1] Write access; indicates whether writes are allowed from the 2-MByte page referenced by this entry.
      */
     UINT64 WriteAccess                                             : 1;
-#define EPDE_2MB_WRITE_ACCESS_BIT                                    1
-#define EPDE_2MB_WRITE_ACCESS_FLAG                                   0x02
-#define EPDE_2MB_WRITE_ACCESS_MASK                                   0x01
-#define EPDE_2MB_WRITE_ACCESS(_)                                     (((_) >> 1) & 0x01)
+#define EPT_PDE_2MB_WRITE_ACCESS_BIT                                 1
+#define EPT_PDE_2MB_WRITE_ACCESS_FLAG                                0x02
+#define EPT_PDE_2MB_WRITE_ACCESS_MASK                                0x01
+#define EPT_PDE_2MB_WRITE_ACCESS(_)                                  (((_) >> 1) & 0x01)
 
     /**
      * [Bit 2] If the "mode-based execute control for EPT" VM-execution control is 0, execute access; indicates whether
@@ -18574,10 +19245,10 @@ typedef union
      * allowed from supervisor-mode linear addresses in the 2-MByte page controlled by this entry.
      */
     UINT64 ExecuteAccess                                           : 1;
-#define EPDE_2MB_EXECUTE_ACCESS_BIT                                  2
-#define EPDE_2MB_EXECUTE_ACCESS_FLAG                                 0x04
-#define EPDE_2MB_EXECUTE_ACCESS_MASK                                 0x01
-#define EPDE_2MB_EXECUTE_ACCESS(_)                                   (((_) >> 2) & 0x01)
+#define EPT_PDE_2MB_EXECUTE_ACCESS_BIT                               2
+#define EPT_PDE_2MB_EXECUTE_ACCESS_FLAG                              0x04
+#define EPT_PDE_2MB_EXECUTE_ACCESS_MASK                              0x01
+#define EPT_PDE_2MB_EXECUTE_ACCESS(_)                                (((_) >> 2) & 0x01)
 
     /**
      * [Bits 5:3] EPT memory type for this 2-MByte page.
@@ -18585,10 +19256,10 @@ typedef union
      * @see Vol3C[28.2.6(EPT and memory Typing)]
      */
     UINT64 MemoryType                                              : 3;
-#define EPDE_2MB_MEMORY_TYPE_BIT                                     3
-#define EPDE_2MB_MEMORY_TYPE_FLAG                                    0x38
-#define EPDE_2MB_MEMORY_TYPE_MASK                                    0x07
-#define EPDE_2MB_MEMORY_TYPE(_)                                      (((_) >> 3) & 0x07)
+#define EPT_PDE_2MB_MEMORY_TYPE_BIT                                  3
+#define EPT_PDE_2MB_MEMORY_TYPE_FLAG                                 0x38
+#define EPT_PDE_2MB_MEMORY_TYPE_MASK                                 0x07
+#define EPT_PDE_2MB_MEMORY_TYPE(_)                                   (((_) >> 3) & 0x07)
 
     /**
      * [Bit 6] Ignore PAT memory type for this 2-MByte page.
@@ -18596,19 +19267,19 @@ typedef union
      * @see Vol3C[28.2.6(EPT and memory Typing)]
      */
     UINT64 IgnorePat                                               : 1;
-#define EPDE_2MB_IGNORE_PAT_BIT                                      6
-#define EPDE_2MB_IGNORE_PAT_FLAG                                     0x40
-#define EPDE_2MB_IGNORE_PAT_MASK                                     0x01
-#define EPDE_2MB_IGNORE_PAT(_)                                       (((_) >> 6) & 0x01)
+#define EPT_PDE_2MB_IGNORE_PAT_BIT                                   6
+#define EPT_PDE_2MB_IGNORE_PAT_FLAG                                  0x40
+#define EPT_PDE_2MB_IGNORE_PAT_MASK                                  0x01
+#define EPT_PDE_2MB_IGNORE_PAT(_)                                    (((_) >> 6) & 0x01)
 
     /**
      * [Bit 7] Must be 1 (otherwise, this entry references an EPT page table).
      */
     UINT64 LargePage                                               : 1;
-#define EPDE_2MB_LARGE_PAGE_BIT                                      7
-#define EPDE_2MB_LARGE_PAGE_FLAG                                     0x80
-#define EPDE_2MB_LARGE_PAGE_MASK                                     0x01
-#define EPDE_2MB_LARGE_PAGE(_)                                       (((_) >> 7) & 0x01)
+#define EPT_PDE_2MB_LARGE_PAGE_BIT                                   7
+#define EPT_PDE_2MB_LARGE_PAGE_FLAG                                  0x80
+#define EPT_PDE_2MB_LARGE_PAGE_MASK                                  0x01
+#define EPT_PDE_2MB_LARGE_PAGE(_)                                    (((_) >> 7) & 0x01)
 
     /**
      * [Bit 8] If bit 6 of EPTP is 1, accessed flag for EPT; indicates whether software has accessed the 2-MByte page
@@ -18617,10 +19288,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     UINT64 Accessed                                                : 1;
-#define EPDE_2MB_ACCESSED_BIT                                        8
-#define EPDE_2MB_ACCESSED_FLAG                                       0x100
-#define EPDE_2MB_ACCESSED_MASK                                       0x01
-#define EPDE_2MB_ACCESSED(_)                                         (((_) >> 8) & 0x01)
+#define EPT_PDE_2MB_ACCESSED_BIT                                     8
+#define EPT_PDE_2MB_ACCESSED_FLAG                                    0x100
+#define EPT_PDE_2MB_ACCESSED_MASK                                    0x01
+#define EPT_PDE_2MB_ACCESSED(_)                                      (((_) >> 8) & 0x01)
 
     /**
      * [Bit 9] If bit 6 of EPTP is 1, dirty flag for EPT; indicates whether software has written to the 2-MByte page referenced
@@ -18629,10 +19300,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     UINT64 Dirty                                                   : 1;
-#define EPDE_2MB_DIRTY_BIT                                           9
-#define EPDE_2MB_DIRTY_FLAG                                          0x200
-#define EPDE_2MB_DIRTY_MASK                                          0x01
-#define EPDE_2MB_DIRTY(_)                                            (((_) >> 9) & 0x01)
+#define EPT_PDE_2MB_DIRTY_BIT                                        9
+#define EPT_PDE_2MB_DIRTY_FLAG                                       0x200
+#define EPT_PDE_2MB_DIRTY_MASK                                       0x01
+#define EPT_PDE_2MB_DIRTY(_)                                         (((_) >> 9) & 0x01)
 
     /**
      * [Bit 10] Execute access for user-mode linear addresses. If the "mode-based execute control for EPT" VM-execution control
@@ -18640,20 +19311,20 @@ typedef union
      * by this entry. If that control is 0, this bit is ignored.
      */
     UINT64 UserModeExecute                                         : 1;
-#define EPDE_2MB_USER_MODE_EXECUTE_BIT                               10
-#define EPDE_2MB_USER_MODE_EXECUTE_FLAG                              0x400
-#define EPDE_2MB_USER_MODE_EXECUTE_MASK                              0x01
-#define EPDE_2MB_USER_MODE_EXECUTE(_)                                (((_) >> 10) & 0x01)
+#define EPT_PDE_2MB_USER_MODE_EXECUTE_BIT                            10
+#define EPT_PDE_2MB_USER_MODE_EXECUTE_FLAG                           0x400
+#define EPT_PDE_2MB_USER_MODE_EXECUTE_MASK                           0x01
+#define EPT_PDE_2MB_USER_MODE_EXECUTE(_)                             (((_) >> 10) & 0x01)
     UINT64 Reserved1                                               : 10;
 
     /**
      * [Bits 47:21] Physical address of 4-KByte aligned EPT page-directory-pointer table referenced by this entry.
      */
     UINT64 PageFrameNumber                                         : 27;
-#define EPDE_2MB_PAGE_FRAME_NUMBER_BIT                               21
-#define EPDE_2MB_PAGE_FRAME_NUMBER_FLAG                              0xFFFFFFE00000
-#define EPDE_2MB_PAGE_FRAME_NUMBER_MASK                              0x7FFFFFF
-#define EPDE_2MB_PAGE_FRAME_NUMBER(_)                                (((_) >> 21) & 0x7FFFFFF)
+#define EPT_PDE_2MB_PAGE_FRAME_NUMBER_BIT                            21
+#define EPT_PDE_2MB_PAGE_FRAME_NUMBER_FLAG                           0xFFFFFFE00000
+#define EPT_PDE_2MB_PAGE_FRAME_NUMBER_MASK                           0x7FFFFFF
+#define EPT_PDE_2MB_PAGE_FRAME_NUMBER(_)                             (((_) >> 21) & 0x7FFFFFF)
     UINT64 Reserved2                                               : 15;
 
     /**
@@ -18664,14 +19335,14 @@ typedef union
      * @see Vol3C[25.5.6.1(Convertible EPT Violations)]
      */
     UINT64 SuppressVe                                              : 1;
-#define EPDE_2MB_SUPPRESS_VE_BIT                                     63
-#define EPDE_2MB_SUPPRESS_VE_FLAG                                    0x8000000000000000
-#define EPDE_2MB_SUPPRESS_VE_MASK                                    0x01
-#define EPDE_2MB_SUPPRESS_VE(_)                                      (((_) >> 63) & 0x01)
+#define EPT_PDE_2MB_SUPPRESS_VE_BIT                                  63
+#define EPT_PDE_2MB_SUPPRESS_VE_FLAG                                 0x8000000000000000
+#define EPT_PDE_2MB_SUPPRESS_VE_MASK                                 0x01
+#define EPT_PDE_2MB_SUPPRESS_VE(_)                                   (((_) >> 63) & 0x01)
   };
 
   UINT64 Flags;
-} EPDE_2MB;
+} EPT_PDE_2MB;
 
 /**
  * @brief Format of an EPT Page-Directory Entry (PDE) that References an EPT Page Table
@@ -18684,19 +19355,19 @@ typedef union
      * [Bit 0] Read access; indicates whether reads are allowed from the 2-MByte region controlled by this entry.
      */
     UINT64 ReadAccess                                              : 1;
-#define EPDE_READ_ACCESS_BIT                                         0
-#define EPDE_READ_ACCESS_FLAG                                        0x01
-#define EPDE_READ_ACCESS_MASK                                        0x01
-#define EPDE_READ_ACCESS(_)                                          (((_) >> 0) & 0x01)
+#define EPT_PDE_READ_ACCESS_BIT                                      0
+#define EPT_PDE_READ_ACCESS_FLAG                                     0x01
+#define EPT_PDE_READ_ACCESS_MASK                                     0x01
+#define EPT_PDE_READ_ACCESS(_)                                       (((_) >> 0) & 0x01)
 
     /**
      * [Bit 1] Write access; indicates whether writes are allowed from the 2-MByte region controlled by this entry.
      */
     UINT64 WriteAccess                                             : 1;
-#define EPDE_WRITE_ACCESS_BIT                                        1
-#define EPDE_WRITE_ACCESS_FLAG                                       0x02
-#define EPDE_WRITE_ACCESS_MASK                                       0x01
-#define EPDE_WRITE_ACCESS(_)                                         (((_) >> 1) & 0x01)
+#define EPT_PDE_WRITE_ACCESS_BIT                                     1
+#define EPT_PDE_WRITE_ACCESS_FLAG                                    0x02
+#define EPT_PDE_WRITE_ACCESS_MASK                                    0x01
+#define EPT_PDE_WRITE_ACCESS(_)                                      (((_) >> 1) & 0x01)
 
     /**
      * [Bit 2] If the "mode-based execute control for EPT" VM-execution control is 0, execute access; indicates whether
@@ -18705,10 +19376,10 @@ typedef union
      * allowed from supervisor-mode linear addresses in the 2-MByte region controlled by this entry.
      */
     UINT64 ExecuteAccess                                           : 1;
-#define EPDE_EXECUTE_ACCESS_BIT                                      2
-#define EPDE_EXECUTE_ACCESS_FLAG                                     0x04
-#define EPDE_EXECUTE_ACCESS_MASK                                     0x01
-#define EPDE_EXECUTE_ACCESS(_)                                       (((_) >> 2) & 0x01)
+#define EPT_PDE_EXECUTE_ACCESS_BIT                                   2
+#define EPT_PDE_EXECUTE_ACCESS_FLAG                                  0x04
+#define EPT_PDE_EXECUTE_ACCESS_MASK                                  0x01
+#define EPT_PDE_EXECUTE_ACCESS(_)                                    (((_) >> 2) & 0x01)
     UINT64 Reserved1                                               : 5;
 
     /**
@@ -18718,10 +19389,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     UINT64 Accessed                                                : 1;
-#define EPDE_ACCESSED_BIT                                            8
-#define EPDE_ACCESSED_FLAG                                           0x100
-#define EPDE_ACCESSED_MASK                                           0x01
-#define EPDE_ACCESSED(_)                                             (((_) >> 8) & 0x01)
+#define EPT_PDE_ACCESSED_BIT                                         8
+#define EPT_PDE_ACCESSED_FLAG                                        0x100
+#define EPT_PDE_ACCESSED_MASK                                        0x01
+#define EPT_PDE_ACCESSED(_)                                          (((_) >> 8) & 0x01)
     UINT64 Reserved2                                               : 1;
 
     /**
@@ -18730,25 +19401,25 @@ typedef union
      * by this entry. If that control is 0, this bit is ignored.
      */
     UINT64 UserModeExecute                                         : 1;
-#define EPDE_USER_MODE_EXECUTE_BIT                                   10
-#define EPDE_USER_MODE_EXECUTE_FLAG                                  0x400
-#define EPDE_USER_MODE_EXECUTE_MASK                                  0x01
-#define EPDE_USER_MODE_EXECUTE(_)                                    (((_) >> 10) & 0x01)
+#define EPT_PDE_USER_MODE_EXECUTE_BIT                                10
+#define EPT_PDE_USER_MODE_EXECUTE_FLAG                               0x400
+#define EPT_PDE_USER_MODE_EXECUTE_MASK                               0x01
+#define EPT_PDE_USER_MODE_EXECUTE(_)                                 (((_) >> 10) & 0x01)
     UINT64 Reserved3                                               : 1;
 
     /**
      * [Bits 47:12] Physical address of 4-KByte aligned EPT page table referenced by this entry.
      */
     UINT64 PageFrameNumber                                         : 36;
-#define EPDE_PAGE_FRAME_NUMBER_BIT                                   12
-#define EPDE_PAGE_FRAME_NUMBER_FLAG                                  0xFFFFFFFFF000
-#define EPDE_PAGE_FRAME_NUMBER_MASK                                  0xFFFFFFFFF
-#define EPDE_PAGE_FRAME_NUMBER(_)                                    (((_) >> 12) & 0xFFFFFFFFF)
+#define EPT_PDE_PAGE_FRAME_NUMBER_BIT                                12
+#define EPT_PDE_PAGE_FRAME_NUMBER_FLAG                               0xFFFFFFFFF000
+#define EPT_PDE_PAGE_FRAME_NUMBER_MASK                               0xFFFFFFFFF
+#define EPT_PDE_PAGE_FRAME_NUMBER(_)                                 (((_) >> 12) & 0xFFFFFFFFF)
     UINT64 Reserved4                                               : 16;
   };
 
   UINT64 Flags;
-} EPDE;
+} EPT_PDE;
 
 /**
  * @brief Format of an EPT Page-Table Entry that Maps a 4-KByte Page
@@ -18761,19 +19432,19 @@ typedef union
      * [Bit 0] Read access; indicates whether reads are allowed from the 4-KByte page referenced by this entry.
      */
     UINT64 ReadAccess                                              : 1;
-#define EPTE_READ_ACCESS_BIT                                         0
-#define EPTE_READ_ACCESS_FLAG                                        0x01
-#define EPTE_READ_ACCESS_MASK                                        0x01
-#define EPTE_READ_ACCESS(_)                                          (((_) >> 0) & 0x01)
+#define EPT_PTE_READ_ACCESS_BIT                                      0
+#define EPT_PTE_READ_ACCESS_FLAG                                     0x01
+#define EPT_PTE_READ_ACCESS_MASK                                     0x01
+#define EPT_PTE_READ_ACCESS(_)                                       (((_) >> 0) & 0x01)
 
     /**
      * [Bit 1] Write access; indicates whether writes are allowed from the 4-KByte page referenced by this entry.
      */
     UINT64 WriteAccess                                             : 1;
-#define EPTE_WRITE_ACCESS_BIT                                        1
-#define EPTE_WRITE_ACCESS_FLAG                                       0x02
-#define EPTE_WRITE_ACCESS_MASK                                       0x01
-#define EPTE_WRITE_ACCESS(_)                                         (((_) >> 1) & 0x01)
+#define EPT_PTE_WRITE_ACCESS_BIT                                     1
+#define EPT_PTE_WRITE_ACCESS_FLAG                                    0x02
+#define EPT_PTE_WRITE_ACCESS_MASK                                    0x01
+#define EPT_PTE_WRITE_ACCESS(_)                                      (((_) >> 1) & 0x01)
 
     /**
      * [Bit 2] If the "mode-based execute control for EPT" VM-execution control is 0, execute access; indicates whether
@@ -18782,10 +19453,10 @@ typedef union
      * allowed from supervisor-mode linear addresses in the 4-KByte page controlled by this entry.
      */
     UINT64 ExecuteAccess                                           : 1;
-#define EPTE_EXECUTE_ACCESS_BIT                                      2
-#define EPTE_EXECUTE_ACCESS_FLAG                                     0x04
-#define EPTE_EXECUTE_ACCESS_MASK                                     0x01
-#define EPTE_EXECUTE_ACCESS(_)                                       (((_) >> 2) & 0x01)
+#define EPT_PTE_EXECUTE_ACCESS_BIT                                   2
+#define EPT_PTE_EXECUTE_ACCESS_FLAG                                  0x04
+#define EPT_PTE_EXECUTE_ACCESS_MASK                                  0x01
+#define EPT_PTE_EXECUTE_ACCESS(_)                                    (((_) >> 2) & 0x01)
 
     /**
      * [Bits 5:3] EPT memory type for this 4-KByte page.
@@ -18793,10 +19464,10 @@ typedef union
      * @see Vol3C[28.2.6(EPT and memory Typing)]
      */
     UINT64 MemoryType                                              : 3;
-#define EPTE_MEMORY_TYPE_BIT                                         3
-#define EPTE_MEMORY_TYPE_FLAG                                        0x38
-#define EPTE_MEMORY_TYPE_MASK                                        0x07
-#define EPTE_MEMORY_TYPE(_)                                          (((_) >> 3) & 0x07)
+#define EPT_PTE_MEMORY_TYPE_BIT                                      3
+#define EPT_PTE_MEMORY_TYPE_FLAG                                     0x38
+#define EPT_PTE_MEMORY_TYPE_MASK                                     0x07
+#define EPT_PTE_MEMORY_TYPE(_)                                       (((_) >> 3) & 0x07)
 
     /**
      * [Bit 6] Ignore PAT memory type for this 4-KByte page.
@@ -18804,10 +19475,10 @@ typedef union
      * @see Vol3C[28.2.6(EPT and memory Typing)]
      */
     UINT64 IgnorePat                                               : 1;
-#define EPTE_IGNORE_PAT_BIT                                          6
-#define EPTE_IGNORE_PAT_FLAG                                         0x40
-#define EPTE_IGNORE_PAT_MASK                                         0x01
-#define EPTE_IGNORE_PAT(_)                                           (((_) >> 6) & 0x01)
+#define EPT_PTE_IGNORE_PAT_BIT                                       6
+#define EPT_PTE_IGNORE_PAT_FLAG                                      0x40
+#define EPT_PTE_IGNORE_PAT_MASK                                      0x01
+#define EPT_PTE_IGNORE_PAT(_)                                        (((_) >> 6) & 0x01)
     UINT64 Reserved1                                               : 1;
 
     /**
@@ -18817,10 +19488,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     UINT64 Accessed                                                : 1;
-#define EPTE_ACCESSED_BIT                                            8
-#define EPTE_ACCESSED_FLAG                                           0x100
-#define EPTE_ACCESSED_MASK                                           0x01
-#define EPTE_ACCESSED(_)                                             (((_) >> 8) & 0x01)
+#define EPT_PTE_ACCESSED_BIT                                         8
+#define EPT_PTE_ACCESSED_FLAG                                        0x100
+#define EPT_PTE_ACCESSED_MASK                                        0x01
+#define EPT_PTE_ACCESSED(_)                                          (((_) >> 8) & 0x01)
 
     /**
      * [Bit 9] If bit 6 of EPTP is 1, dirty flag for EPT; indicates whether software has written to the 4-KByte page referenced
@@ -18829,10 +19500,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     UINT64 Dirty                                                   : 1;
-#define EPTE_DIRTY_BIT                                               9
-#define EPTE_DIRTY_FLAG                                              0x200
-#define EPTE_DIRTY_MASK                                              0x01
-#define EPTE_DIRTY(_)                                                (((_) >> 9) & 0x01)
+#define EPT_PTE_DIRTY_BIT                                            9
+#define EPT_PTE_DIRTY_FLAG                                           0x200
+#define EPT_PTE_DIRTY_MASK                                           0x01
+#define EPT_PTE_DIRTY(_)                                             (((_) >> 9) & 0x01)
 
     /**
      * [Bit 10] Execute access for user-mode linear addresses. If the "mode-based execute control for EPT" VM-execution control
@@ -18840,20 +19511,20 @@ typedef union
      * by this entry. If that control is 0, this bit is ignored.
      */
     UINT64 UserModeExecute                                         : 1;
-#define EPTE_USER_MODE_EXECUTE_BIT                                   10
-#define EPTE_USER_MODE_EXECUTE_FLAG                                  0x400
-#define EPTE_USER_MODE_EXECUTE_MASK                                  0x01
-#define EPTE_USER_MODE_EXECUTE(_)                                    (((_) >> 10) & 0x01)
+#define EPT_PTE_USER_MODE_EXECUTE_BIT                                10
+#define EPT_PTE_USER_MODE_EXECUTE_FLAG                               0x400
+#define EPT_PTE_USER_MODE_EXECUTE_MASK                               0x01
+#define EPT_PTE_USER_MODE_EXECUTE(_)                                 (((_) >> 10) & 0x01)
     UINT64 Reserved2                                               : 1;
 
     /**
      * [Bits 47:12] Physical address of the 4-KByte page referenced by this entry.
      */
     UINT64 PageFrameNumber                                         : 36;
-#define EPTE_PAGE_FRAME_NUMBER_BIT                                   12
-#define EPTE_PAGE_FRAME_NUMBER_FLAG                                  0xFFFFFFFFF000
-#define EPTE_PAGE_FRAME_NUMBER_MASK                                  0xFFFFFFFFF
-#define EPTE_PAGE_FRAME_NUMBER(_)                                    (((_) >> 12) & 0xFFFFFFFFF)
+#define EPT_PTE_PAGE_FRAME_NUMBER_BIT                                12
+#define EPT_PTE_PAGE_FRAME_NUMBER_FLAG                               0xFFFFFFFFF000
+#define EPT_PTE_PAGE_FRAME_NUMBER_MASK                               0xFFFFFFFFF
+#define EPT_PTE_PAGE_FRAME_NUMBER(_)                                 (((_) >> 12) & 0xFFFFFFFFF)
     UINT64 Reserved3                                               : 15;
 
     /**
@@ -18864,14 +19535,14 @@ typedef union
      * @see Vol3C[25.5.6.1(Convertible EPT Violations)]
      */
     UINT64 SuppressVe                                              : 1;
-#define EPTE_SUPPRESS_VE_BIT                                         63
-#define EPTE_SUPPRESS_VE_FLAG                                        0x8000000000000000
-#define EPTE_SUPPRESS_VE_MASK                                        0x01
-#define EPTE_SUPPRESS_VE(_)                                          (((_) >> 63) & 0x01)
+#define EPT_PTE_SUPPRESS_VE_BIT                                      63
+#define EPT_PTE_SUPPRESS_VE_FLAG                                     0x8000000000000000
+#define EPT_PTE_SUPPRESS_VE_MASK                                     0x01
+#define EPT_PTE_SUPPRESS_VE(_)                                       (((_) >> 63) & 0x01)
   };
 
   UINT64 Flags;
-} EPTE;
+} EPT_PTE;
 
 /**
  * @brief Format of a common EPT Entry
@@ -19539,9 +20210,24 @@ typedef union
 #define VMCS_CTRL_ENCLS_EXITING_BITMAP                               0x0000202E
 
 /**
+ * Sub-page-permission-table pointer.
+ */
+#define VMCS_CTRL_SUB_PAGE_PERMISSION_TABLE_POINTER                  0x00002030
+
+/**
  * TSC multiplier.
  */
 #define VMCS_CTRL_TSC_MULTIPLIER                                     0x00002032
+
+/**
+ * Tertiary processor-based VM-execution controls.
+ */
+#define VMCS_CTRL_TERTIARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS     0x00002034
+
+/**
+ * ENCLV-exiting bitmap.
+ */
+#define VMCS_CTRL_ENCLV_EXITING_BITMAP                               0x00002036
 /**
  * @}
  */
@@ -19622,6 +20308,11 @@ typedef union
  * Guest IA32_RTIT_CTL.
  */
 #define VMCS_GUEST_RTIT_CTL                                          0x00002814
+
+/**
+ * Guest IA32_PKRS
+ */
+#define VMCS_GUEST_PKRS                                              0x00002818
 /**
  * @}
  */
@@ -19647,6 +20338,11 @@ typedef union
  * Host IA32_PERF_GLOBAL_CTRL.
  */
 #define VMCS_HOST_PERF_GLOBAL_CTRL                                   0x00002C04
+
+/**
+ * Host IA32_PKRS
+ */
+#define VMCS_HOST_PKRS                                               0x00002C06
 /**
  * @}
  */

--- a/out/ia32.hpp
+++ b/out/ia32.hpp
@@ -491,7 +491,21 @@ typedef union
 #define CR4_USERMODE_INSTRUCTION_PREVENTION_FLAG                     0x800
 #define CR4_USERMODE_INSTRUCTION_PREVENTION_MASK                     0x01
 #define CR4_USERMODE_INSTRUCTION_PREVENTION(_)                       (((_) >> 11) & 0x01)
-    uint64_t reserved1                                               : 1;
+
+    /**
+     * @brief 57-bit Linear Addresses
+     *
+     * [Bit 12] When set in IA-32e mode, the processor uses 5-level paging to translate 57-bit linear addresses. When clear in
+     * IA-32e mode, the processor uses 4-level paging to translate 48-bit linear addresses. This bit cannot be modified in
+     * IA-32e mode.
+     *
+     * @see Vol3C[4(PAGING)]
+     */
+    uint64_t linear_addresses_57_bit                                 : 1;
+#define CR4_LINEAR_ADDRESSES_57_BIT_BIT                              12
+#define CR4_LINEAR_ADDRESSES_57_BIT_FLAG                             0x1000
+#define CR4_LINEAR_ADDRESSES_57_BIT_MASK                             0x01
+#define CR4_LINEAR_ADDRESSES_57_BIT(_)                               (((_) >> 12) & 0x01)
 
     /**
      * @brief VMX-Enable
@@ -518,7 +532,7 @@ typedef union
 #define CR4_SMX_ENABLE_FLAG                                          0x4000
 #define CR4_SMX_ENABLE_MASK                                          0x01
 #define CR4_SMX_ENABLE(_)                                            (((_) >> 14) & 0x01)
-    uint64_t reserved2                                               : 1;
+    uint64_t reserved1                                               : 1;
 
     /**
      * @brief FSGSBASE-Enable
@@ -562,7 +576,20 @@ typedef union
 #define CR4_OS_XSAVE_FLAG                                            0x40000
 #define CR4_OS_XSAVE_MASK                                            0x01
 #define CR4_OS_XSAVE(_)                                              (((_) >> 18) & 0x01)
-    uint64_t reserved3                                               : 1;
+
+    /**
+     * @brief Key-Locker-Enable
+     *
+     * [Bit 19] When set, the LOADIWKEY instruction is enabled; in addition, if support for the AES Key Locker instructions has
+     * been activated by system firmware, CPUID.19H:EBX.AESKLE[bit 0] is enumerated as 1 and the AES Key Locker instructions
+     * are enabled. When clear, CPUID.19H:EBX.AESKLE[bit 0] is enumerated as 0 and execution of any Key Locker instruction
+     * causes an invalid-opcode exception (\#UD).
+     */
+    uint64_t key_locker_enable                                       : 1;
+#define CR4_KEY_LOCKER_ENABLE_BIT                                    19
+#define CR4_KEY_LOCKER_ENABLE_FLAG                                   0x80000
+#define CR4_KEY_LOCKER_ENABLE_MASK                                   0x01
+#define CR4_KEY_LOCKER_ENABLE(_)                                     (((_) >> 19) & 0x01)
 
     /**
      * @brief SMEP-Enable
@@ -602,7 +629,34 @@ typedef union
 #define CR4_PROTECTION_KEY_ENABLE_FLAG                               0x400000
 #define CR4_PROTECTION_KEY_ENABLE_MASK                               0x01
 #define CR4_PROTECTION_KEY_ENABLE(_)                                 (((_) >> 22) & 0x01)
-    uint64_t reserved4                                               : 41;
+
+    /**
+     * @brief Control-flow Enforcement Technology
+     *
+     * [Bit 23] Enables control-flow enforcement technology when set. This flag can be set only if CR0.WP is set, and it must
+     * be clear before CR0.WP can be cleared.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t control_flow_enforcement_enable                         : 1;
+#define CR4_CONTROL_FLOW_ENFORCEMENT_ENABLE_BIT                      23
+#define CR4_CONTROL_FLOW_ENFORCEMENT_ENABLE_FLAG                     0x800000
+#define CR4_CONTROL_FLOW_ENFORCEMENT_ENABLE_MASK                     0x01
+#define CR4_CONTROL_FLOW_ENFORCEMENT_ENABLE(_)                       (((_) >> 23) & 0x01)
+
+    /**
+     * @brief Enable protection keys for supervisor-mode pages
+     *
+     * [Bit 24] 4-level paging and 5-level paging associate each supervisor-mode linear address with a protection key. When
+     * set, this flag allows use of the IA32_PKRS MSR to specify, for each protection key, whether supervisor-mode linear
+     * addresses with that protection key can be read or written.
+     */
+    uint64_t protection_key_for_supervisor_mode_enable               : 1;
+#define CR4_PROTECTION_KEY_FOR_SUPERVISOR_MODE_ENABLE_BIT            24
+#define CR4_PROTECTION_KEY_FOR_SUPERVISOR_MODE_ENABLE_FLAG           0x1000000
+#define CR4_PROTECTION_KEY_FOR_SUPERVISOR_MODE_ENABLE_MASK           0x01
+#define CR4_PROTECTION_KEY_FOR_SUPERVISOR_MODE_ENABLE(_)             (((_) >> 24) & 0x01)
+    uint64_t reserved2                                               : 39;
   };
 
   uint64_t flags;
@@ -2814,7 +2868,109 @@ typedef struct
 #define CPUID_ECX_OSPKE_FLAG                                         0x10
 #define CPUID_ECX_OSPKE_MASK                                         0x01
 #define CPUID_ECX_OSPKE(_)                                           (((_) >> 4) & 0x01)
-      uint32_t reserved1                                             : 12;
+
+      /**
+       * [Bit 5] WAITPKG.
+       */
+      uint32_t waitpkg                                               : 1;
+#define CPUID_ECX_WAITPKG_BIT                                        5
+#define CPUID_ECX_WAITPKG_FLAG                                       0x20
+#define CPUID_ECX_WAITPKG_MASK                                       0x01
+#define CPUID_ECX_WAITPKG(_)                                         (((_) >> 5) & 0x01)
+
+      /**
+       * [Bit 6] AVX512_VBMI2.
+       */
+      uint32_t avx512_vbmi2                                          : 1;
+#define CPUID_ECX_AVX512_VBMI2_BIT                                   6
+#define CPUID_ECX_AVX512_VBMI2_FLAG                                  0x40
+#define CPUID_ECX_AVX512_VBMI2_MASK                                  0x01
+#define CPUID_ECX_AVX512_VBMI2(_)                                    (((_) >> 6) & 0x01)
+
+      /**
+       * [Bit 7] Supports CET shadow stack features if 1. Processors that set this bit define bits 1:0 of the IA32_U_CET and
+       * IA32_S_CET MSRs. Enumerates support for the following MSRs: IA32_INTERRUPT_SPP_TABLE_ADDR, IA32_PL3_SSP, IA32_PL2_SSP,
+       * IA32_PL1_SSP, and IA32_PL0_SSP.
+       */
+      uint32_t cet_ss                                                : 1;
+#define CPUID_ECX_CET_SS_BIT                                         7
+#define CPUID_ECX_CET_SS_FLAG                                        0x80
+#define CPUID_ECX_CET_SS_MASK                                        0x01
+#define CPUID_ECX_CET_SS(_)                                          (((_) >> 7) & 0x01)
+
+      /**
+       * [Bit 8] GFNI.
+       */
+      uint32_t gfni                                                  : 1;
+#define CPUID_ECX_GFNI_BIT                                           8
+#define CPUID_ECX_GFNI_FLAG                                          0x100
+#define CPUID_ECX_GFNI_MASK                                          0x01
+#define CPUID_ECX_GFNI(_)                                            (((_) >> 8) & 0x01)
+
+      /**
+       * [Bit 9] VAES.
+       */
+      uint32_t vaes                                                  : 1;
+#define CPUID_ECX_VAES_BIT                                           9
+#define CPUID_ECX_VAES_FLAG                                          0x200
+#define CPUID_ECX_VAES_MASK                                          0x01
+#define CPUID_ECX_VAES(_)                                            (((_) >> 9) & 0x01)
+
+      /**
+       * [Bit 10] VPCLMULQDQ.
+       */
+      uint32_t vpclmulqdq                                            : 1;
+#define CPUID_ECX_VPCLMULQDQ_BIT                                     10
+#define CPUID_ECX_VPCLMULQDQ_FLAG                                    0x400
+#define CPUID_ECX_VPCLMULQDQ_MASK                                    0x01
+#define CPUID_ECX_VPCLMULQDQ(_)                                      (((_) >> 10) & 0x01)
+
+      /**
+       * [Bit 11] AVX512_VNNI.
+       */
+      uint32_t avx512_vnni                                           : 1;
+#define CPUID_ECX_AVX512_VNNI_BIT                                    11
+#define CPUID_ECX_AVX512_VNNI_FLAG                                   0x800
+#define CPUID_ECX_AVX512_VNNI_MASK                                   0x01
+#define CPUID_ECX_AVX512_VNNI(_)                                     (((_) >> 11) & 0x01)
+
+      /**
+       * [Bit 12] AVX512_BITALG.
+       */
+      uint32_t avx512_bitalg                                         : 1;
+#define CPUID_ECX_AVX512_BITALG_BIT                                  12
+#define CPUID_ECX_AVX512_BITALG_FLAG                                 0x1000
+#define CPUID_ECX_AVX512_BITALG_MASK                                 0x01
+#define CPUID_ECX_AVX512_BITALG(_)                                   (((_) >> 12) & 0x01)
+
+      /**
+       * [Bit 13] If 1, the following MSRs are supported: IA32_TME_CAPABILITY, IA32_TME_ACTIVATE, IA32_TME_EXCLUDE_MASK, and
+       * IA32_TME_EXCLUDE_BASE.
+       */
+      uint32_t tme_en                                                : 1;
+#define CPUID_ECX_TME_EN_BIT                                         13
+#define CPUID_ECX_TME_EN_FLAG                                        0x2000
+#define CPUID_ECX_TME_EN_MASK                                        0x01
+#define CPUID_ECX_TME_EN(_)                                          (((_) >> 13) & 0x01)
+
+      /**
+       * [Bit 14] AVX512_VPOPCNTDQ.
+       */
+      uint32_t avx512_vpopcntdq                                      : 1;
+#define CPUID_ECX_AVX512_VPOPCNTDQ_BIT                               14
+#define CPUID_ECX_AVX512_VPOPCNTDQ_FLAG                              0x4000
+#define CPUID_ECX_AVX512_VPOPCNTDQ_MASK                              0x01
+#define CPUID_ECX_AVX512_VPOPCNTDQ(_)                                (((_) >> 14) & 0x01)
+      uint32_t reserved1                                             : 1;
+
+      /**
+       * [Bit 16] Supports 57-bit linear addresses and five-level paging if 1.
+       */
+      uint32_t la57                                                  : 1;
+#define CPUID_ECX_LA57_BIT                                           16
+#define CPUID_ECX_LA57_FLAG                                          0x10000
+#define CPUID_ECX_LA57_MASK                                          0x01
+#define CPUID_ECX_LA57(_)                                            (((_) >> 16) & 0x01)
 
       /**
        * [Bits 21:17] The value of MAWAU used by the BNDLDX and BNDSTX instructions in 64-bit mode.
@@ -2833,7 +2989,45 @@ typedef struct
 #define CPUID_ECX_RDPID_FLAG                                         0x400000
 #define CPUID_ECX_RDPID_MASK                                         0x01
 #define CPUID_ECX_RDPID(_)                                           (((_) >> 22) & 0x01)
-      uint32_t reserved2                                             : 7;
+
+      /**
+       * [Bit 23] KL. Supports Key Locker if 1.
+       */
+      uint32_t kl                                                    : 1;
+#define CPUID_ECX_KL_BIT                                             23
+#define CPUID_ECX_KL_FLAG                                            0x800000
+#define CPUID_ECX_KL_MASK                                            0x01
+#define CPUID_ECX_KL(_)                                              (((_) >> 23) & 0x01)
+      uint32_t reserved2                                             : 1;
+
+      /**
+       * [Bit 25] Supports cache line demote if 1.
+       */
+      uint32_t cldemote                                              : 1;
+#define CPUID_ECX_CLDEMOTE_BIT                                       25
+#define CPUID_ECX_CLDEMOTE_FLAG                                      0x2000000
+#define CPUID_ECX_CLDEMOTE_MASK                                      0x01
+#define CPUID_ECX_CLDEMOTE(_)                                        (((_) >> 25) & 0x01)
+      uint32_t reserved3                                             : 1;
+
+      /**
+       * [Bit 27] Supports MOVDIRI if 1.
+       */
+      uint32_t movdiri                                               : 1;
+#define CPUID_ECX_MOVDIRI_BIT                                        27
+#define CPUID_ECX_MOVDIRI_FLAG                                       0x8000000
+#define CPUID_ECX_MOVDIRI_MASK                                       0x01
+#define CPUID_ECX_MOVDIRI(_)                                         (((_) >> 27) & 0x01)
+
+      /**
+       * [Bit 28] Supports MOVDIR64B if 1.
+       */
+      uint32_t movdir64b                                             : 1;
+#define CPUID_ECX_MOVDIR64B_BIT                                      28
+#define CPUID_ECX_MOVDIR64B_FLAG                                     0x10000000
+#define CPUID_ECX_MOVDIR64B_MASK                                     0x01
+#define CPUID_ECX_MOVDIR64B(_)                                       (((_) >> 28) & 0x01)
+      uint32_t reserved4                                             : 1;
 
       /**
        * [Bit 30] Supports SGX Launch Configuration if 1.
@@ -2843,7 +3037,15 @@ typedef struct
 #define CPUID_ECX_SGX_LC_FLAG                                        0x40000000
 #define CPUID_ECX_SGX_LC_MASK                                        0x01
 #define CPUID_ECX_SGX_LC(_)                                          (((_) >> 30) & 0x01)
-      uint32_t reserved3                                             : 1;
+
+      /**
+       * [Bit 31] Supports protection keys for supervisor-mode pages if 1.
+       */
+      uint32_t pks                                                   : 1;
+#define CPUID_ECX_PKS_BIT                                            31
+#define CPUID_ECX_PKS_FLAG                                           0x80000000
+#define CPUID_ECX_PKS_MASK                                           0x01
+#define CPUID_ECX_PKS(_)                                             (((_) >> 31) & 0x01)
     };
 
     uint32_t flags;
@@ -2853,14 +3055,145 @@ typedef struct
   {
     struct
     {
+      uint32_t reserved1                                             : 2;
+
       /**
-       * [Bits 31:0] EDX is reserved.
+       * [Bit 2] (Intel(R) Xeon Phi(TM) only.)
        */
-      uint32_t reserved                                              : 32;
-#define CPUID_EDX_RESERVED_BIT                                       0
-#define CPUID_EDX_RESERVED_FLAG                                      0xFFFFFFFF
-#define CPUID_EDX_RESERVED_MASK                                      0xFFFFFFFF
-#define CPUID_EDX_RESERVED(_)                                        (((_) >> 0) & 0xFFFFFFFF)
+      uint32_t avx512_4vnniw                                         : 1;
+#define CPUID_EDX_AVX512_4VNNIW_BIT                                  2
+#define CPUID_EDX_AVX512_4VNNIW_FLAG                                 0x04
+#define CPUID_EDX_AVX512_4VNNIW_MASK                                 0x01
+#define CPUID_EDX_AVX512_4VNNIW(_)                                   (((_) >> 2) & 0x01)
+
+      /**
+       * [Bit 3] (Intel(R) Xeon Phi(TM) only.)
+       */
+      uint32_t avx512_4fmaps                                         : 1;
+#define CPUID_EDX_AVX512_4FMAPS_BIT                                  3
+#define CPUID_EDX_AVX512_4FMAPS_FLAG                                 0x08
+#define CPUID_EDX_AVX512_4FMAPS_MASK                                 0x01
+#define CPUID_EDX_AVX512_4FMAPS(_)                                   (((_) >> 3) & 0x01)
+
+      /**
+       * [Bit 4] Fast Short REP MOV.
+       */
+      uint32_t fast_short_rep_mov                                    : 1;
+#define CPUID_EDX_FAST_SHORT_REP_MOV_BIT                             4
+#define CPUID_EDX_FAST_SHORT_REP_MOV_FLAG                            0x10
+#define CPUID_EDX_FAST_SHORT_REP_MOV_MASK                            0x01
+#define CPUID_EDX_FAST_SHORT_REP_MOV(_)                              (((_) >> 4) & 0x01)
+      uint32_t reserved2                                             : 3;
+
+      /**
+       * [Bit 8] AVX512_VP2INTERSECT.
+       */
+      uint32_t avx512_vp2intersect                                   : 1;
+#define CPUID_EDX_AVX512_VP2INTERSECT_BIT                            8
+#define CPUID_EDX_AVX512_VP2INTERSECT_FLAG                           0x100
+#define CPUID_EDX_AVX512_VP2INTERSECT_MASK                           0x01
+#define CPUID_EDX_AVX512_VP2INTERSECT(_)                             (((_) >> 8) & 0x01)
+      uint32_t reserved3                                             : 1;
+
+      /**
+       * [Bit 10] MD_CLEAR supported.
+       */
+      uint32_t md_clear                                              : 1;
+#define CPUID_EDX_MD_CLEAR_BIT                                       10
+#define CPUID_EDX_MD_CLEAR_FLAG                                      0x400
+#define CPUID_EDX_MD_CLEAR_MASK                                      0x01
+#define CPUID_EDX_MD_CLEAR(_)                                        (((_) >> 10) & 0x01)
+      uint32_t reserved4                                             : 4;
+
+      /**
+       * [Bit 15] If 1, the processor is identified as a hybrid part.
+       */
+      uint32_t hybrid                                                : 1;
+#define CPUID_EDX_HYBRID_BIT                                         15
+#define CPUID_EDX_HYBRID_FLAG                                        0x8000
+#define CPUID_EDX_HYBRID_MASK                                        0x01
+#define CPUID_EDX_HYBRID(_)                                          (((_) >> 15) & 0x01)
+      uint32_t reserved5                                             : 2;
+
+      /**
+       * [Bit 18] Supports PCONFIG if 1.
+       */
+      uint32_t pconfig                                               : 1;
+#define CPUID_EDX_PCONFIG_BIT                                        18
+#define CPUID_EDX_PCONFIG_FLAG                                       0x40000
+#define CPUID_EDX_PCONFIG_MASK                                       0x01
+#define CPUID_EDX_PCONFIG(_)                                         (((_) >> 18) & 0x01)
+      uint32_t reserved6                                             : 1;
+
+      /**
+       * [Bit 20] Supports CET indirect branch tracking features if 1. Processors that set this bit define bits 5:2 and bits
+       * 63:10 of the IA32_U_CET and IA32_S_CET MSRs.
+       */
+      uint32_t cet_ibt                                               : 1;
+#define CPUID_EDX_CET_IBT_BIT                                        20
+#define CPUID_EDX_CET_IBT_FLAG                                       0x100000
+#define CPUID_EDX_CET_IBT_MASK                                       0x01
+#define CPUID_EDX_CET_IBT(_)                                         (((_) >> 20) & 0x01)
+      uint32_t reserved7                                             : 5;
+
+      /**
+       * [Bit 26] Enumerates support for indirect branch restricted speculation (IBRS) and the indirect branch predictor barrier
+       * (IBPB). Processors that set this bit support the IA32_SPEC_CTRL MSR and the IA32_PRED_CMD MSR. They allow software to
+       * set IA32_SPEC_CTRL[0] (IBRS) and IA32_PRED_CMD[0] (IBPB).
+       */
+      uint32_t ibrs_ibpb                                             : 1;
+#define CPUID_EDX_IBRS_IBPB_BIT                                      26
+#define CPUID_EDX_IBRS_IBPB_FLAG                                     0x4000000
+#define CPUID_EDX_IBRS_IBPB_MASK                                     0x01
+#define CPUID_EDX_IBRS_IBPB(_)                                       (((_) >> 26) & 0x01)
+
+      /**
+       * [Bit 27] Enumerates support for single thread indirect branch predictors (STIBP). Processors that set this bit support
+       * the IA32_SPEC_CTRL MSR. They allow software to set IA32_SPEC_CTRL[1] (STIBP).
+       */
+      uint32_t stibp                                                 : 1;
+#define CPUID_EDX_STIBP_BIT                                          27
+#define CPUID_EDX_STIBP_FLAG                                         0x8000000
+#define CPUID_EDX_STIBP_MASK                                         0x01
+#define CPUID_EDX_STIBP(_)                                           (((_) >> 27) & 0x01)
+
+      /**
+       * [Bit 28] Enumerates support for L1D_FLUSH. Processors that set this bit support the IA32_FLUSH_CMD MSR. They allow
+       * software to set IA32_FLUSH_CMD[0] (L1D_FLUSH).
+       */
+      uint32_t l1d_flush                                             : 1;
+#define CPUID_EDX_L1D_FLUSH_BIT                                      28
+#define CPUID_EDX_L1D_FLUSH_FLAG                                     0x10000000
+#define CPUID_EDX_L1D_FLUSH_MASK                                     0x01
+#define CPUID_EDX_L1D_FLUSH(_)                                       (((_) >> 28) & 0x01)
+
+      /**
+       * [Bit 29] Enumerates support for the IA32_ARCH_CAPABILITIES MSR.
+       */
+      uint32_t ia32_arch_capabilities                                : 1;
+#define CPUID_EDX_IA32_ARCH_CAPABILITIES_BIT                         29
+#define CPUID_EDX_IA32_ARCH_CAPABILITIES_FLAG                        0x20000000
+#define CPUID_EDX_IA32_ARCH_CAPABILITIES_MASK                        0x01
+#define CPUID_EDX_IA32_ARCH_CAPABILITIES(_)                          (((_) >> 29) & 0x01)
+
+      /**
+       * [Bit 30] Enumerates support for the IA32_CORE_CAPABILITIES MSR.
+       */
+      uint32_t ia32_core_capabilities                                : 1;
+#define CPUID_EDX_IA32_CORE_CAPABILITIES_BIT                         30
+#define CPUID_EDX_IA32_CORE_CAPABILITIES_FLAG                        0x40000000
+#define CPUID_EDX_IA32_CORE_CAPABILITIES_MASK                        0x01
+#define CPUID_EDX_IA32_CORE_CAPABILITIES(_)                          (((_) >> 30) & 0x01)
+
+      /**
+       * [Bit 31] Enumerates support for Speculative Store Bypass Disable (SSBD). Processors that set this bit support the
+       * IA32_SPEC_CTRL MSR. They allow software to set IA32_SPEC_CTRL[2] (SSBD).
+       */
+      uint32_t ssbd                                                  : 1;
+#define CPUID_EDX_SSBD_BIT                                           31
+#define CPUID_EDX_SSBD_FLAG                                          0x80000000
+#define CPUID_EDX_SSBD_MASK                                          0x01
+#define CPUID_EDX_SSBD(_)                                            (((_) >> 31) & 0x01)
     };
 
     uint32_t flags;
@@ -10582,7 +10915,39 @@ typedef union
 #define IA32_VMX_EXIT_CTLS_CONCEAL_VMX_FROM_PT_FLAG                  0x1000000
 #define IA32_VMX_EXIT_CTLS_CONCEAL_VMX_FROM_PT_MASK                  0x01
 #define IA32_VMX_EXIT_CTLS_CONCEAL_VMX_FROM_PT(_)                    (((_) >> 24) & 0x01)
-    uint64_t reserved6                                               : 39;
+
+    /**
+     * [Bit 25] This control determines whether the IA32_RTIT_CTL MSR is cleared on VM exit.
+     *
+     * @see Vol3C[35(INTEL(R) PROCESSOR TRACE)]
+     */
+    uint64_t clear_ia32_rtit_ctl                                     : 1;
+#define IA32_VMX_EXIT_CTLS_CLEAR_IA32_RTIT_CTL_BIT                   25
+#define IA32_VMX_EXIT_CTLS_CLEAR_IA32_RTIT_CTL_FLAG                  0x2000000
+#define IA32_VMX_EXIT_CTLS_CLEAR_IA32_RTIT_CTL_MASK                  0x01
+#define IA32_VMX_EXIT_CTLS_CLEAR_IA32_RTIT_CTL(_)                    (((_) >> 25) & 0x01)
+    uint64_t reserved6                                               : 2;
+
+    /**
+     * [Bit 28] This control determines whether CET-related MSRs and SPP are loaded on VM exit.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t load_ia32_cet_state                                     : 1;
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_CET_STATE_BIT                   28
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_CET_STATE_FLAG                  0x10000000
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_CET_STATE_MASK                  0x01
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_CET_STATE(_)                    (((_) >> 28) & 0x01)
+
+    /**
+     * [Bit 29] This control determines whether the IA32_PKRS MSR is loaded on VM exit.
+     */
+    uint64_t load_ia32_pkrs                                          : 1;
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_PKRS_BIT                        29
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_PKRS_FLAG                       0x20000000
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_PKRS_MASK                       0x01
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_PKRS(_)                         (((_) >> 29) & 0x01)
+    uint64_t reserved7                                               : 34;
   };
 
   uint64_t flags;
@@ -10729,7 +11094,17 @@ typedef union
 #define IA32_VMX_ENTRY_CTLS_LOAD_CET_STATE_FLAG                      0x100000
 #define IA32_VMX_ENTRY_CTLS_LOAD_CET_STATE_MASK                      0x01
 #define IA32_VMX_ENTRY_CTLS_LOAD_CET_STATE(_)                        (((_) >> 20) & 0x01)
-    uint64_t reserved5                                               : 43;
+    uint64_t reserved5                                               : 1;
+
+    /**
+     * [Bit 22] This control determines whether the IA32_PKRS MSR is loaded on VM entry.
+     */
+    uint64_t load_ia32_pkrs                                          : 1;
+#define IA32_VMX_ENTRY_CTLS_LOAD_IA32_PKRS_BIT                       22
+#define IA32_VMX_ENTRY_CTLS_LOAD_IA32_PKRS_FLAG                      0x400000
+#define IA32_VMX_ENTRY_CTLS_LOAD_IA32_PKRS_MASK                      0x01
+#define IA32_VMX_ENTRY_CTLS_LOAD_IA32_PKRS(_)                        (((_) >> 22) & 0x01)
+    uint64_t reserved6                                               : 41;
   };
 
   uint64_t flags;
@@ -12466,6 +12841,302 @@ typedef union
  * @see Vol3B[18.6.3.4(Debug Store (DS) Mechanism)]
  */
 #define IA32_DS_AREA                                                 0x00000600
+
+/**
+ * Configure User Mode CET
+ *
+ * @remarks - Bits 1:0 are defined if CPUID.(EAX=07H,ECX=0H):ECX.CET_SS[07] = 1. - Bits 5:2 and bits 63:10 are defined if
+ *          CPUID.(EAX=07H,ECX=0H):EDX.CET_IBT[20] = 1.
+ */
+#define IA32_U_CET                                                   0x000006A0
+typedef union
+{
+  struct
+  {
+    /**
+     * [Bit 0] When set to 1, enable shadow stacks at CPL3.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t sh_stk_en                                               : 1;
+#define IA32_U_CET_SH_STK_EN_BIT                                     0
+#define IA32_U_CET_SH_STK_EN_FLAG                                    0x01
+#define IA32_U_CET_SH_STK_EN_MASK                                    0x01
+#define IA32_U_CET_SH_STK_EN(_)                                      (((_) >> 0) & 0x01)
+
+    /**
+     * [Bit 1] When set to 1, enables the WRSSD/WRSSQ instructions.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t wr_shstk_en                                             : 1;
+#define IA32_U_CET_WR_SHSTK_EN_BIT                                   1
+#define IA32_U_CET_WR_SHSTK_EN_FLAG                                  0x02
+#define IA32_U_CET_WR_SHSTK_EN_MASK                                  0x01
+#define IA32_U_CET_WR_SHSTK_EN(_)                                    (((_) >> 1) & 0x01)
+
+    /**
+     * [Bit 2] When set to 1, enables indirect branch tracking
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t endbr_en                                                : 1;
+#define IA32_U_CET_ENDBR_EN_BIT                                      2
+#define IA32_U_CET_ENDBR_EN_FLAG                                     0x04
+#define IA32_U_CET_ENDBR_EN_MASK                                     0x01
+#define IA32_U_CET_ENDBR_EN(_)                                       (((_) >> 2) & 0x01)
+
+    /**
+     * [Bit 3] Enable legacy compatibility treatment for indirect branch tracking.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t leg_iw_en                                               : 1;
+#define IA32_U_CET_LEG_IW_EN_BIT                                     3
+#define IA32_U_CET_LEG_IW_EN_FLAG                                    0x08
+#define IA32_U_CET_LEG_IW_EN_MASK                                    0x01
+#define IA32_U_CET_LEG_IW_EN(_)                                      (((_) >> 3) & 0x01)
+
+    /**
+     * [Bit 4] When set to 1, enables use of no-track prefix for indirect branch tracking.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t no_track_en                                             : 1;
+#define IA32_U_CET_NO_TRACK_EN_BIT                                   4
+#define IA32_U_CET_NO_TRACK_EN_FLAG                                  0x10
+#define IA32_U_CET_NO_TRACK_EN_MASK                                  0x01
+#define IA32_U_CET_NO_TRACK_EN(_)                                    (((_) >> 4) & 0x01)
+
+    /**
+     * [Bit 5] When set to 1, disables suppression of CET indirect branch tracking on legacy compatibility.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t suppress_dis                                            : 1;
+#define IA32_U_CET_SUPPRESS_DIS_BIT                                  5
+#define IA32_U_CET_SUPPRESS_DIS_FLAG                                 0x20
+#define IA32_U_CET_SUPPRESS_DIS_MASK                                 0x01
+#define IA32_U_CET_SUPPRESS_DIS(_)                                   (((_) >> 5) & 0x01)
+    uint64_t reserved1                                               : 4;
+
+    /**
+     * [Bit 10] When set to 1, indirect branch tracking is suppressed. This bit can be written to 1 only if TRACKER is written
+     * as IDLE.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t suppress                                                : 1;
+#define IA32_U_CET_SUPPRESS_BIT                                      10
+#define IA32_U_CET_SUPPRESS_FLAG                                     0x400
+#define IA32_U_CET_SUPPRESS_MASK                                     0x01
+#define IA32_U_CET_SUPPRESS(_)                                       (((_) >> 10) & 0x01)
+
+    /**
+     * [Bit 11] Value of the indirect branch tracking state machine. Values: IDLE (0), WAIT_FOR_ENDBRANCH(1).
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t tracker                                                 : 1;
+#define IA32_U_CET_TRACKER_BIT                                       11
+#define IA32_U_CET_TRACKER_FLAG                                      0x800
+#define IA32_U_CET_TRACKER_MASK                                      0x01
+#define IA32_U_CET_TRACKER(_)                                        (((_) >> 11) & 0x01)
+
+    /**
+     * [Bits 63:12] Linear address bits 63:12 of a legacy code page bitmap used for legacy compatibility when indirect branch
+     * tracking is enabled. If the processor does not support Intel 64 architecture, these fields have only 32 bits; bits 63:32
+     * of the MSRs are reserved. On processors that support Intel 64 architecture this value cannot represent a non-canonical
+     * address. In protected mode, only 31:0 are loaded. The linear address written must be aligned to 8 bytes and bits 2:0
+     * must be 0 (hardware requires bits 1:0 to be 0).
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t eb_leg_bitmap_base                                      : 52;
+#define IA32_U_CET_EB_LEG_BITMAP_BASE_BIT                            12
+#define IA32_U_CET_EB_LEG_BITMAP_BASE_FLAG                           0xFFFFFFFFFFFFF000
+#define IA32_U_CET_EB_LEG_BITMAP_BASE_MASK                           0xFFFFFFFFFFFFF
+#define IA32_U_CET_EB_LEG_BITMAP_BASE(_)                             (((_) >> 12) & 0xFFFFFFFFFFFFF)
+  };
+
+  uint64_t flags;
+} ia32_u_cet_register;
+
+
+/**
+ * Configure Supervisor Mode CET
+ *
+ * @remarks - Bits 1:0 are defined if CPUID.(EAX=07H,ECX=0H):ECX.CET_SS[07] = 1. - Bits 5:2 and bits 63:10 are defined if
+ *          CPUID.(EAX=07H,ECX=0H):EDX.CET_IBT[20] = 1.
+ */
+#define IA32_S_CET                                                   0x000006A2
+typedef union
+{
+  struct
+  {
+    /**
+     * [Bit 0] When set to 1, enable shadow stacks at CPL3.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t sh_stk_en                                               : 1;
+#define IA32_S_CET_SH_STK_EN_BIT                                     0
+#define IA32_S_CET_SH_STK_EN_FLAG                                    0x01
+#define IA32_S_CET_SH_STK_EN_MASK                                    0x01
+#define IA32_S_CET_SH_STK_EN(_)                                      (((_) >> 0) & 0x01)
+
+    /**
+     * [Bit 1] When set to 1, enables the WRSSD/WRSSQ instructions.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t wr_shstk_en                                             : 1;
+#define IA32_S_CET_WR_SHSTK_EN_BIT                                   1
+#define IA32_S_CET_WR_SHSTK_EN_FLAG                                  0x02
+#define IA32_S_CET_WR_SHSTK_EN_MASK                                  0x01
+#define IA32_S_CET_WR_SHSTK_EN(_)                                    (((_) >> 1) & 0x01)
+
+    /**
+     * [Bit 2] When set to 1, enables indirect branch tracking
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t endbr_en                                                : 1;
+#define IA32_S_CET_ENDBR_EN_BIT                                      2
+#define IA32_S_CET_ENDBR_EN_FLAG                                     0x04
+#define IA32_S_CET_ENDBR_EN_MASK                                     0x01
+#define IA32_S_CET_ENDBR_EN(_)                                       (((_) >> 2) & 0x01)
+
+    /**
+     * [Bit 3] Enable legacy compatibility treatment for indirect branch tracking.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t leg_iw_en                                               : 1;
+#define IA32_S_CET_LEG_IW_EN_BIT                                     3
+#define IA32_S_CET_LEG_IW_EN_FLAG                                    0x08
+#define IA32_S_CET_LEG_IW_EN_MASK                                    0x01
+#define IA32_S_CET_LEG_IW_EN(_)                                      (((_) >> 3) & 0x01)
+
+    /**
+     * [Bit 4] When set to 1, enables use of no-track prefix for indirect branch tracking.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t no_track_en                                             : 1;
+#define IA32_S_CET_NO_TRACK_EN_BIT                                   4
+#define IA32_S_CET_NO_TRACK_EN_FLAG                                  0x10
+#define IA32_S_CET_NO_TRACK_EN_MASK                                  0x01
+#define IA32_S_CET_NO_TRACK_EN(_)                                    (((_) >> 4) & 0x01)
+
+    /**
+     * [Bit 5] When set to 1, disables suppression of CET indirect branch tracking on legacy compatibility.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t suppress_dis                                            : 1;
+#define IA32_S_CET_SUPPRESS_DIS_BIT                                  5
+#define IA32_S_CET_SUPPRESS_DIS_FLAG                                 0x20
+#define IA32_S_CET_SUPPRESS_DIS_MASK                                 0x01
+#define IA32_S_CET_SUPPRESS_DIS(_)                                   (((_) >> 5) & 0x01)
+    uint64_t reserved1                                               : 4;
+
+    /**
+     * [Bit 10] When set to 1, indirect branch tracking is suppressed. This bit can be written to 1 only if TRACKER is written
+     * as IDLE.
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t suppress                                                : 1;
+#define IA32_S_CET_SUPPRESS_BIT                                      10
+#define IA32_S_CET_SUPPRESS_FLAG                                     0x400
+#define IA32_S_CET_SUPPRESS_MASK                                     0x01
+#define IA32_S_CET_SUPPRESS(_)                                       (((_) >> 10) & 0x01)
+
+    /**
+     * [Bit 11] Value of the indirect branch tracking state machine. Values: IDLE (0), WAIT_FOR_ENDBRANCH(1).
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t tracker                                                 : 1;
+#define IA32_S_CET_TRACKER_BIT                                       11
+#define IA32_S_CET_TRACKER_FLAG                                      0x800
+#define IA32_S_CET_TRACKER_MASK                                      0x01
+#define IA32_S_CET_TRACKER(_)                                        (((_) >> 11) & 0x01)
+
+    /**
+     * [Bits 63:12] Linear address bits 63:12 of a legacy code page bitmap used for legacy compatibility when indirect branch
+     * tracking is enabled. If the processor does not support Intel 64 architecture, these fields have only 32 bits; bits 63:32
+     * of the MSRs are reserved. On processors that support Intel 64 architecture this value cannot represent a non-canonical
+     * address. In protected mode, only 31:0 are loaded. The linear address written must be aligned to 8 bytes and bits 2:0
+     * must be 0 (hardware requires bits 1:0 to be 0).
+     *
+     * @see Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+     */
+    uint64_t eb_leg_bitmap_base                                      : 52;
+#define IA32_S_CET_EB_LEG_BITMAP_BASE_BIT                            12
+#define IA32_S_CET_EB_LEG_BITMAP_BASE_FLAG                           0xFFFFFFFFFFFFF000
+#define IA32_S_CET_EB_LEG_BITMAP_BASE_MASK                           0xFFFFFFFFFFFFF
+#define IA32_S_CET_EB_LEG_BITMAP_BASE(_)                             (((_) >> 12) & 0xFFFFFFFFFFFFF)
+  };
+
+  uint64_t flags;
+} ia32_s_cet_register;
+
+
+/**
+ * Linear address to be loaded into SSP on transition to privilege level 0.
+ * If the processor does not support Intel 64 architecture, these fields have only 32 bits; bits 63:32 of the MSRs are
+ * reserved. On processors that support Intel 64 architecture this value cannot represent a non-canonical address. In
+ * protected mode, only 31:0 are loaded. The linear address written must be aligned to 8 bytes and bits 2:0 must be 0
+ * (hardware requires bits 1:0 to be 0).
+ *
+ * @remarks If CPUID.(EAX=07H, ECX=0H):ECX.CET_SS[07] = 1
+ */
+#define IA32_PL0_SSP                                                 0x000006A4
+
+/**
+ * Linear address to be loaded into SSP on transition to privilege level 1.
+ * If the processor does not support Intel 64 architecture, these fields have only 32 bits; bits 63:32 of the MSRs are
+ * reserved. On processors that support Intel 64 architecture this value cannot represent a non-canonical address. In
+ * protected mode, only 31:0 are loaded. The linear address written must be aligned to 8 bytes and bits 2:0 must be 0
+ * (hardware requires bits 1:0 to be 0).
+ *
+ * @remarks If CPUID.(EAX=07H, ECX=0H):ECX.CET_SS[07] = 1
+ */
+#define IA32_PL1_SSP                                                 0x000006A5
+
+/**
+ * Linear address to be loaded into SSP on transition to privilege level 2.
+ * If the processor does not support Intel 64 architecture, these fields have only 32 bits; bits 63:32 of the MSRs are
+ * reserved. On processors that support Intel 64 architecture this value cannot represent a non-canonical address. In
+ * protected mode, only 31:0 are loaded. The linear address written must be aligned to 8 bytes and bits 2:0 must be 0
+ * (hardware requires bits 1:0 to be 0).
+ *
+ * @remarks If CPUID.(EAX=07H, ECX=0H):ECX.CET_SS[07] = 1
+ */
+#define IA32_PL2_SSP                                                 0x000006A6
+
+/**
+ * Linear address to be loaded into SSP on transition to privilege level 3.
+ * If the processor does not support Intel 64 architecture, these fields have only 32 bits; bits 63:32 of the MSRs are
+ * reserved. On processors that support Intel 64 architecture this value cannot represent a non-canonical address. In
+ * protected mode, only 31:0 are loaded. The linear address written must be aligned to 8 bytes and bits 2:0 must be 0
+ * (hardware requires bits 1:0 to be 0).
+ *
+ * @remarks If CPUID.(EAX=07H, ECX=0H):ECX.CET_SS[07] = 1
+ */
+#define IA32_PL3_SSP                                                 0x000006A7
+
+/**
+ * Linear address of a table of seven shadow stack pointers that are selected in IA-32e mode using the IST index (when not
+ * 0) from the interrupt gate descriptor.
+ * This MSR is not present on processors that do not support Intel 64 architecture. This field cannot represent a
+ * non-canonical address.
+ *
+ * @remarks If CPUID.(EAX=07H, ECX=0H):ECX.CET_SS[07] = 1
+ */
+#define IA32_INTERRUPT_SSP_TABLE_ADDR                                0x000006A8
 
 /**
  * TSC Target of Local APIC's TSC Deadline Mode.
@@ -18268,19 +18939,19 @@ typedef union
      * [Bit 0] Read access; indicates whether reads are allowed from the 512-GByte region controlled by this entry.
      */
     uint64_t read_access                                             : 1;
-#define EPT_PML4_READ_ACCESS_BIT                                     0
-#define EPT_PML4_READ_ACCESS_FLAG                                    0x01
-#define EPT_PML4_READ_ACCESS_MASK                                    0x01
-#define EPT_PML4_READ_ACCESS(_)                                      (((_) >> 0) & 0x01)
+#define EPT_PML4E_READ_ACCESS_BIT                                    0
+#define EPT_PML4E_READ_ACCESS_FLAG                                   0x01
+#define EPT_PML4E_READ_ACCESS_MASK                                   0x01
+#define EPT_PML4E_READ_ACCESS(_)                                     (((_) >> 0) & 0x01)
 
     /**
      * [Bit 1] Write access; indicates whether writes are allowed from the 512-GByte region controlled by this entry.
      */
     uint64_t write_access                                            : 1;
-#define EPT_PML4_WRITE_ACCESS_BIT                                    1
-#define EPT_PML4_WRITE_ACCESS_FLAG                                   0x02
-#define EPT_PML4_WRITE_ACCESS_MASK                                   0x01
-#define EPT_PML4_WRITE_ACCESS(_)                                     (((_) >> 1) & 0x01)
+#define EPT_PML4E_WRITE_ACCESS_BIT                                   1
+#define EPT_PML4E_WRITE_ACCESS_FLAG                                  0x02
+#define EPT_PML4E_WRITE_ACCESS_MASK                                  0x01
+#define EPT_PML4E_WRITE_ACCESS(_)                                    (((_) >> 1) & 0x01)
 
     /**
      * [Bit 2] If the "mode-based execute control for EPT" VM-execution control is 0, execute access; indicates whether
@@ -18289,10 +18960,10 @@ typedef union
      * allowed from supervisor-mode linear addresses in the 512-GByte region controlled by this entry.
      */
     uint64_t execute_access                                          : 1;
-#define EPT_PML4_EXECUTE_ACCESS_BIT                                  2
-#define EPT_PML4_EXECUTE_ACCESS_FLAG                                 0x04
-#define EPT_PML4_EXECUTE_ACCESS_MASK                                 0x01
-#define EPT_PML4_EXECUTE_ACCESS(_)                                   (((_) >> 2) & 0x01)
+#define EPT_PML4E_EXECUTE_ACCESS_BIT                                 2
+#define EPT_PML4E_EXECUTE_ACCESS_FLAG                                0x04
+#define EPT_PML4E_EXECUTE_ACCESS_MASK                                0x01
+#define EPT_PML4E_EXECUTE_ACCESS(_)                                  (((_) >> 2) & 0x01)
     uint64_t reserved1                                               : 5;
 
     /**
@@ -18302,10 +18973,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     uint64_t accessed                                                : 1;
-#define EPT_PML4_ACCESSED_BIT                                        8
-#define EPT_PML4_ACCESSED_FLAG                                       0x100
-#define EPT_PML4_ACCESSED_MASK                                       0x01
-#define EPT_PML4_ACCESSED(_)                                         (((_) >> 8) & 0x01)
+#define EPT_PML4E_ACCESSED_BIT                                       8
+#define EPT_PML4E_ACCESSED_FLAG                                      0x100
+#define EPT_PML4E_ACCESSED_MASK                                      0x01
+#define EPT_PML4E_ACCESSED(_)                                        (((_) >> 8) & 0x01)
     uint64_t reserved2                                               : 1;
 
     /**
@@ -18314,25 +18985,25 @@ typedef union
      * controlled by this entry. If that control is 0, this bit is ignored.
      */
     uint64_t user_mode_execute                                       : 1;
-#define EPT_PML4_USER_MODE_EXECUTE_BIT                               10
-#define EPT_PML4_USER_MODE_EXECUTE_FLAG                              0x400
-#define EPT_PML4_USER_MODE_EXECUTE_MASK                              0x01
-#define EPT_PML4_USER_MODE_EXECUTE(_)                                (((_) >> 10) & 0x01)
+#define EPT_PML4E_USER_MODE_EXECUTE_BIT                              10
+#define EPT_PML4E_USER_MODE_EXECUTE_FLAG                             0x400
+#define EPT_PML4E_USER_MODE_EXECUTE_MASK                             0x01
+#define EPT_PML4E_USER_MODE_EXECUTE(_)                               (((_) >> 10) & 0x01)
     uint64_t reserved3                                               : 1;
 
     /**
      * [Bits 47:12] Physical address of 4-KByte aligned EPT page-directory-pointer table referenced by this entry.
      */
     uint64_t page_frame_number                                       : 36;
-#define EPT_PML4_PAGE_FRAME_NUMBER_BIT                               12
-#define EPT_PML4_PAGE_FRAME_NUMBER_FLAG                              0xFFFFFFFFF000
-#define EPT_PML4_PAGE_FRAME_NUMBER_MASK                              0xFFFFFFFFF
-#define EPT_PML4_PAGE_FRAME_NUMBER(_)                                (((_) >> 12) & 0xFFFFFFFFF)
+#define EPT_PML4E_PAGE_FRAME_NUMBER_BIT                              12
+#define EPT_PML4E_PAGE_FRAME_NUMBER_FLAG                             0xFFFFFFFFF000
+#define EPT_PML4E_PAGE_FRAME_NUMBER_MASK                             0xFFFFFFFFF
+#define EPT_PML4E_PAGE_FRAME_NUMBER(_)                               (((_) >> 12) & 0xFFFFFFFFF)
     uint64_t reserved4                                               : 16;
   };
 
   uint64_t flags;
-} ept_pml4;
+} ept_pml4e;
 
 /**
  * @brief Format of an EPT Page-Directory-Pointer-Table Entry (PDPTE) that Maps a 1-GByte Page
@@ -18345,19 +19016,19 @@ typedef union
      * [Bit 0] Read access; indicates whether reads are allowed from the 1-GByte page referenced by this entry.
      */
     uint64_t read_access                                             : 1;
-#define EPDPTE_1GB_READ_ACCESS_BIT                                   0
-#define EPDPTE_1GB_READ_ACCESS_FLAG                                  0x01
-#define EPDPTE_1GB_READ_ACCESS_MASK                                  0x01
-#define EPDPTE_1GB_READ_ACCESS(_)                                    (((_) >> 0) & 0x01)
+#define EPT_PDPTE_1GB_READ_ACCESS_BIT                                0
+#define EPT_PDPTE_1GB_READ_ACCESS_FLAG                               0x01
+#define EPT_PDPTE_1GB_READ_ACCESS_MASK                               0x01
+#define EPT_PDPTE_1GB_READ_ACCESS(_)                                 (((_) >> 0) & 0x01)
 
     /**
      * [Bit 1] Write access; indicates whether writes are allowed from the 1-GByte page referenced by this entry.
      */
     uint64_t write_access                                            : 1;
-#define EPDPTE_1GB_WRITE_ACCESS_BIT                                  1
-#define EPDPTE_1GB_WRITE_ACCESS_FLAG                                 0x02
-#define EPDPTE_1GB_WRITE_ACCESS_MASK                                 0x01
-#define EPDPTE_1GB_WRITE_ACCESS(_)                                   (((_) >> 1) & 0x01)
+#define EPT_PDPTE_1GB_WRITE_ACCESS_BIT                               1
+#define EPT_PDPTE_1GB_WRITE_ACCESS_FLAG                              0x02
+#define EPT_PDPTE_1GB_WRITE_ACCESS_MASK                              0x01
+#define EPT_PDPTE_1GB_WRITE_ACCESS(_)                                (((_) >> 1) & 0x01)
 
     /**
      * [Bit 2] If the "mode-based execute control for EPT" VM-execution control is 0, execute access; indicates whether
@@ -18366,10 +19037,10 @@ typedef union
      * allowed from supervisor-mode linear addresses in the 1-GByte page controlled by this entry.
      */
     uint64_t execute_access                                          : 1;
-#define EPDPTE_1GB_EXECUTE_ACCESS_BIT                                2
-#define EPDPTE_1GB_EXECUTE_ACCESS_FLAG                               0x04
-#define EPDPTE_1GB_EXECUTE_ACCESS_MASK                               0x01
-#define EPDPTE_1GB_EXECUTE_ACCESS(_)                                 (((_) >> 2) & 0x01)
+#define EPT_PDPTE_1GB_EXECUTE_ACCESS_BIT                             2
+#define EPT_PDPTE_1GB_EXECUTE_ACCESS_FLAG                            0x04
+#define EPT_PDPTE_1GB_EXECUTE_ACCESS_MASK                            0x01
+#define EPT_PDPTE_1GB_EXECUTE_ACCESS(_)                              (((_) >> 2) & 0x01)
 
     /**
      * [Bits 5:3] EPT memory type for this 1-GByte page.
@@ -18377,10 +19048,10 @@ typedef union
      * @see Vol3C[28.2.6(EPT and memory Typing)]
      */
     uint64_t memory_type                                             : 3;
-#define EPDPTE_1GB_MEMORY_TYPE_BIT                                   3
-#define EPDPTE_1GB_MEMORY_TYPE_FLAG                                  0x38
-#define EPDPTE_1GB_MEMORY_TYPE_MASK                                  0x07
-#define EPDPTE_1GB_MEMORY_TYPE(_)                                    (((_) >> 3) & 0x07)
+#define EPT_PDPTE_1GB_MEMORY_TYPE_BIT                                3
+#define EPT_PDPTE_1GB_MEMORY_TYPE_FLAG                               0x38
+#define EPT_PDPTE_1GB_MEMORY_TYPE_MASK                               0x07
+#define EPT_PDPTE_1GB_MEMORY_TYPE(_)                                 (((_) >> 3) & 0x07)
 
     /**
      * [Bit 6] Ignore PAT memory type for this 1-GByte page.
@@ -18388,19 +19059,19 @@ typedef union
      * @see Vol3C[28.2.6(EPT and memory Typing)]
      */
     uint64_t ignore_pat                                              : 1;
-#define EPDPTE_1GB_IGNORE_PAT_BIT                                    6
-#define EPDPTE_1GB_IGNORE_PAT_FLAG                                   0x40
-#define EPDPTE_1GB_IGNORE_PAT_MASK                                   0x01
-#define EPDPTE_1GB_IGNORE_PAT(_)                                     (((_) >> 6) & 0x01)
+#define EPT_PDPTE_1GB_IGNORE_PAT_BIT                                 6
+#define EPT_PDPTE_1GB_IGNORE_PAT_FLAG                                0x40
+#define EPT_PDPTE_1GB_IGNORE_PAT_MASK                                0x01
+#define EPT_PDPTE_1GB_IGNORE_PAT(_)                                  (((_) >> 6) & 0x01)
 
     /**
      * [Bit 7] Must be 1 (otherwise, this entry references an EPT page directory).
      */
     uint64_t large_page                                              : 1;
-#define EPDPTE_1GB_LARGE_PAGE_BIT                                    7
-#define EPDPTE_1GB_LARGE_PAGE_FLAG                                   0x80
-#define EPDPTE_1GB_LARGE_PAGE_MASK                                   0x01
-#define EPDPTE_1GB_LARGE_PAGE(_)                                     (((_) >> 7) & 0x01)
+#define EPT_PDPTE_1GB_LARGE_PAGE_BIT                                 7
+#define EPT_PDPTE_1GB_LARGE_PAGE_FLAG                                0x80
+#define EPT_PDPTE_1GB_LARGE_PAGE_MASK                                0x01
+#define EPT_PDPTE_1GB_LARGE_PAGE(_)                                  (((_) >> 7) & 0x01)
 
     /**
      * [Bit 8] If bit 6 of EPTP is 1, accessed flag for EPT; indicates whether software has accessed the 1-GByte page
@@ -18409,10 +19080,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     uint64_t accessed                                                : 1;
-#define EPDPTE_1GB_ACCESSED_BIT                                      8
-#define EPDPTE_1GB_ACCESSED_FLAG                                     0x100
-#define EPDPTE_1GB_ACCESSED_MASK                                     0x01
-#define EPDPTE_1GB_ACCESSED(_)                                       (((_) >> 8) & 0x01)
+#define EPT_PDPTE_1GB_ACCESSED_BIT                                   8
+#define EPT_PDPTE_1GB_ACCESSED_FLAG                                  0x100
+#define EPT_PDPTE_1GB_ACCESSED_MASK                                  0x01
+#define EPT_PDPTE_1GB_ACCESSED(_)                                    (((_) >> 8) & 0x01)
 
     /**
      * [Bit 9] If bit 6 of EPTP is 1, dirty flag for EPT; indicates whether software has written to the 1-GByte page referenced
@@ -18421,10 +19092,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     uint64_t dirty                                                   : 1;
-#define EPDPTE_1GB_DIRTY_BIT                                         9
-#define EPDPTE_1GB_DIRTY_FLAG                                        0x200
-#define EPDPTE_1GB_DIRTY_MASK                                        0x01
-#define EPDPTE_1GB_DIRTY(_)                                          (((_) >> 9) & 0x01)
+#define EPT_PDPTE_1GB_DIRTY_BIT                                      9
+#define EPT_PDPTE_1GB_DIRTY_FLAG                                     0x200
+#define EPT_PDPTE_1GB_DIRTY_MASK                                     0x01
+#define EPT_PDPTE_1GB_DIRTY(_)                                       (((_) >> 9) & 0x01)
 
     /**
      * [Bit 10] Execute access for user-mode linear addresses. If the "mode-based execute control for EPT" VM-execution control
@@ -18432,20 +19103,20 @@ typedef union
      * by this entry. If that control is 0, this bit is ignored.
      */
     uint64_t user_mode_execute                                       : 1;
-#define EPDPTE_1GB_USER_MODE_EXECUTE_BIT                             10
-#define EPDPTE_1GB_USER_MODE_EXECUTE_FLAG                            0x400
-#define EPDPTE_1GB_USER_MODE_EXECUTE_MASK                            0x01
-#define EPDPTE_1GB_USER_MODE_EXECUTE(_)                              (((_) >> 10) & 0x01)
+#define EPT_PDPTE_1GB_USER_MODE_EXECUTE_BIT                          10
+#define EPT_PDPTE_1GB_USER_MODE_EXECUTE_FLAG                         0x400
+#define EPT_PDPTE_1GB_USER_MODE_EXECUTE_MASK                         0x01
+#define EPT_PDPTE_1GB_USER_MODE_EXECUTE(_)                           (((_) >> 10) & 0x01)
     uint64_t reserved1                                               : 19;
 
     /**
      * [Bits 47:30] Physical address of 4-KByte aligned EPT page-directory-pointer table referenced by this entry.
      */
     uint64_t page_frame_number                                       : 18;
-#define EPDPTE_1GB_PAGE_FRAME_NUMBER_BIT                             30
-#define EPDPTE_1GB_PAGE_FRAME_NUMBER_FLAG                            0xFFFFC0000000
-#define EPDPTE_1GB_PAGE_FRAME_NUMBER_MASK                            0x3FFFF
-#define EPDPTE_1GB_PAGE_FRAME_NUMBER(_)                              (((_) >> 30) & 0x3FFFF)
+#define EPT_PDPTE_1GB_PAGE_FRAME_NUMBER_BIT                          30
+#define EPT_PDPTE_1GB_PAGE_FRAME_NUMBER_FLAG                         0xFFFFC0000000
+#define EPT_PDPTE_1GB_PAGE_FRAME_NUMBER_MASK                         0x3FFFF
+#define EPT_PDPTE_1GB_PAGE_FRAME_NUMBER(_)                           (((_) >> 30) & 0x3FFFF)
     uint64_t reserved2                                               : 15;
 
     /**
@@ -18456,14 +19127,14 @@ typedef union
      * @see Vol3C[25.5.6.1(Convertible EPT Violations)]
      */
     uint64_t suppress_ve                                             : 1;
-#define EPDPTE_1GB_SUPPRESS_VE_BIT                                   63
-#define EPDPTE_1GB_SUPPRESS_VE_FLAG                                  0x8000000000000000
-#define EPDPTE_1GB_SUPPRESS_VE_MASK                                  0x01
-#define EPDPTE_1GB_SUPPRESS_VE(_)                                    (((_) >> 63) & 0x01)
+#define EPT_PDPTE_1GB_SUPPRESS_VE_BIT                                63
+#define EPT_PDPTE_1GB_SUPPRESS_VE_FLAG                               0x8000000000000000
+#define EPT_PDPTE_1GB_SUPPRESS_VE_MASK                               0x01
+#define EPT_PDPTE_1GB_SUPPRESS_VE(_)                                 (((_) >> 63) & 0x01)
   };
 
   uint64_t flags;
-} epdpte_1gb;
+} ept_pdpte_1gb;
 
 /**
  * @brief Format of an EPT Page-Directory-Pointer-Table Entry (PDPTE) that References an EPT Page Directory
@@ -18476,19 +19147,19 @@ typedef union
      * [Bit 0] Read access; indicates whether reads are allowed from the 1-GByte region controlled by this entry.
      */
     uint64_t read_access                                             : 1;
-#define EPDPTE_READ_ACCESS_BIT                                       0
-#define EPDPTE_READ_ACCESS_FLAG                                      0x01
-#define EPDPTE_READ_ACCESS_MASK                                      0x01
-#define EPDPTE_READ_ACCESS(_)                                        (((_) >> 0) & 0x01)
+#define EPT_PDPTE_READ_ACCESS_BIT                                    0
+#define EPT_PDPTE_READ_ACCESS_FLAG                                   0x01
+#define EPT_PDPTE_READ_ACCESS_MASK                                   0x01
+#define EPT_PDPTE_READ_ACCESS(_)                                     (((_) >> 0) & 0x01)
 
     /**
      * [Bit 1] Write access; indicates whether writes are allowed from the 1-GByte region controlled by this entry.
      */
     uint64_t write_access                                            : 1;
-#define EPDPTE_WRITE_ACCESS_BIT                                      1
-#define EPDPTE_WRITE_ACCESS_FLAG                                     0x02
-#define EPDPTE_WRITE_ACCESS_MASK                                     0x01
-#define EPDPTE_WRITE_ACCESS(_)                                       (((_) >> 1) & 0x01)
+#define EPT_PDPTE_WRITE_ACCESS_BIT                                   1
+#define EPT_PDPTE_WRITE_ACCESS_FLAG                                  0x02
+#define EPT_PDPTE_WRITE_ACCESS_MASK                                  0x01
+#define EPT_PDPTE_WRITE_ACCESS(_)                                    (((_) >> 1) & 0x01)
 
     /**
      * [Bit 2] If the "mode-based execute control for EPT" VM-execution control is 0, execute access; indicates whether
@@ -18497,10 +19168,10 @@ typedef union
      * allowed from supervisor-mode linear addresses in the 1-GByte region controlled by this entry.
      */
     uint64_t execute_access                                          : 1;
-#define EPDPTE_EXECUTE_ACCESS_BIT                                    2
-#define EPDPTE_EXECUTE_ACCESS_FLAG                                   0x04
-#define EPDPTE_EXECUTE_ACCESS_MASK                                   0x01
-#define EPDPTE_EXECUTE_ACCESS(_)                                     (((_) >> 2) & 0x01)
+#define EPT_PDPTE_EXECUTE_ACCESS_BIT                                 2
+#define EPT_PDPTE_EXECUTE_ACCESS_FLAG                                0x04
+#define EPT_PDPTE_EXECUTE_ACCESS_MASK                                0x01
+#define EPT_PDPTE_EXECUTE_ACCESS(_)                                  (((_) >> 2) & 0x01)
     uint64_t reserved1                                               : 5;
 
     /**
@@ -18510,10 +19181,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     uint64_t accessed                                                : 1;
-#define EPDPTE_ACCESSED_BIT                                          8
-#define EPDPTE_ACCESSED_FLAG                                         0x100
-#define EPDPTE_ACCESSED_MASK                                         0x01
-#define EPDPTE_ACCESSED(_)                                           (((_) >> 8) & 0x01)
+#define EPT_PDPTE_ACCESSED_BIT                                       8
+#define EPT_PDPTE_ACCESSED_FLAG                                      0x100
+#define EPT_PDPTE_ACCESSED_MASK                                      0x01
+#define EPT_PDPTE_ACCESSED(_)                                        (((_) >> 8) & 0x01)
     uint64_t reserved2                                               : 1;
 
     /**
@@ -18522,25 +19193,25 @@ typedef union
      * by this entry. If that control is 0, this bit is ignored.
      */
     uint64_t user_mode_execute                                       : 1;
-#define EPDPTE_USER_MODE_EXECUTE_BIT                                 10
-#define EPDPTE_USER_MODE_EXECUTE_FLAG                                0x400
-#define EPDPTE_USER_MODE_EXECUTE_MASK                                0x01
-#define EPDPTE_USER_MODE_EXECUTE(_)                                  (((_) >> 10) & 0x01)
+#define EPT_PDPTE_USER_MODE_EXECUTE_BIT                              10
+#define EPT_PDPTE_USER_MODE_EXECUTE_FLAG                             0x400
+#define EPT_PDPTE_USER_MODE_EXECUTE_MASK                             0x01
+#define EPT_PDPTE_USER_MODE_EXECUTE(_)                               (((_) >> 10) & 0x01)
     uint64_t reserved3                                               : 1;
 
     /**
      * [Bits 47:12] Physical address of 4-KByte aligned EPT page-directory-pointer table referenced by this entry.
      */
     uint64_t page_frame_number                                       : 36;
-#define EPDPTE_PAGE_FRAME_NUMBER_BIT                                 12
-#define EPDPTE_PAGE_FRAME_NUMBER_FLAG                                0xFFFFFFFFF000
-#define EPDPTE_PAGE_FRAME_NUMBER_MASK                                0xFFFFFFFFF
-#define EPDPTE_PAGE_FRAME_NUMBER(_)                                  (((_) >> 12) & 0xFFFFFFFFF)
+#define EPT_PDPTE_PAGE_FRAME_NUMBER_BIT                              12
+#define EPT_PDPTE_PAGE_FRAME_NUMBER_FLAG                             0xFFFFFFFFF000
+#define EPT_PDPTE_PAGE_FRAME_NUMBER_MASK                             0xFFFFFFFFF
+#define EPT_PDPTE_PAGE_FRAME_NUMBER(_)                               (((_) >> 12) & 0xFFFFFFFFF)
     uint64_t reserved4                                               : 16;
   };
 
   uint64_t flags;
-} epdpte;
+} ept_pdpte;
 
 /**
  * @brief Format of an EPT Page-Directory Entry (PDE) that Maps a 2-MByte Page
@@ -18553,19 +19224,19 @@ typedef union
      * [Bit 0] Read access; indicates whether reads are allowed from the 2-MByte page referenced by this entry.
      */
     uint64_t read_access                                             : 1;
-#define EPDE_2MB_READ_ACCESS_BIT                                     0
-#define EPDE_2MB_READ_ACCESS_FLAG                                    0x01
-#define EPDE_2MB_READ_ACCESS_MASK                                    0x01
-#define EPDE_2MB_READ_ACCESS(_)                                      (((_) >> 0) & 0x01)
+#define EPT_PDE_2MB_READ_ACCESS_BIT                                  0
+#define EPT_PDE_2MB_READ_ACCESS_FLAG                                 0x01
+#define EPT_PDE_2MB_READ_ACCESS_MASK                                 0x01
+#define EPT_PDE_2MB_READ_ACCESS(_)                                   (((_) >> 0) & 0x01)
 
     /**
      * [Bit 1] Write access; indicates whether writes are allowed from the 2-MByte page referenced by this entry.
      */
     uint64_t write_access                                            : 1;
-#define EPDE_2MB_WRITE_ACCESS_BIT                                    1
-#define EPDE_2MB_WRITE_ACCESS_FLAG                                   0x02
-#define EPDE_2MB_WRITE_ACCESS_MASK                                   0x01
-#define EPDE_2MB_WRITE_ACCESS(_)                                     (((_) >> 1) & 0x01)
+#define EPT_PDE_2MB_WRITE_ACCESS_BIT                                 1
+#define EPT_PDE_2MB_WRITE_ACCESS_FLAG                                0x02
+#define EPT_PDE_2MB_WRITE_ACCESS_MASK                                0x01
+#define EPT_PDE_2MB_WRITE_ACCESS(_)                                  (((_) >> 1) & 0x01)
 
     /**
      * [Bit 2] If the "mode-based execute control for EPT" VM-execution control is 0, execute access; indicates whether
@@ -18574,10 +19245,10 @@ typedef union
      * allowed from supervisor-mode linear addresses in the 2-MByte page controlled by this entry.
      */
     uint64_t execute_access                                          : 1;
-#define EPDE_2MB_EXECUTE_ACCESS_BIT                                  2
-#define EPDE_2MB_EXECUTE_ACCESS_FLAG                                 0x04
-#define EPDE_2MB_EXECUTE_ACCESS_MASK                                 0x01
-#define EPDE_2MB_EXECUTE_ACCESS(_)                                   (((_) >> 2) & 0x01)
+#define EPT_PDE_2MB_EXECUTE_ACCESS_BIT                               2
+#define EPT_PDE_2MB_EXECUTE_ACCESS_FLAG                              0x04
+#define EPT_PDE_2MB_EXECUTE_ACCESS_MASK                              0x01
+#define EPT_PDE_2MB_EXECUTE_ACCESS(_)                                (((_) >> 2) & 0x01)
 
     /**
      * [Bits 5:3] EPT memory type for this 2-MByte page.
@@ -18585,10 +19256,10 @@ typedef union
      * @see Vol3C[28.2.6(EPT and memory Typing)]
      */
     uint64_t memory_type                                             : 3;
-#define EPDE_2MB_MEMORY_TYPE_BIT                                     3
-#define EPDE_2MB_MEMORY_TYPE_FLAG                                    0x38
-#define EPDE_2MB_MEMORY_TYPE_MASK                                    0x07
-#define EPDE_2MB_MEMORY_TYPE(_)                                      (((_) >> 3) & 0x07)
+#define EPT_PDE_2MB_MEMORY_TYPE_BIT                                  3
+#define EPT_PDE_2MB_MEMORY_TYPE_FLAG                                 0x38
+#define EPT_PDE_2MB_MEMORY_TYPE_MASK                                 0x07
+#define EPT_PDE_2MB_MEMORY_TYPE(_)                                   (((_) >> 3) & 0x07)
 
     /**
      * [Bit 6] Ignore PAT memory type for this 2-MByte page.
@@ -18596,19 +19267,19 @@ typedef union
      * @see Vol3C[28.2.6(EPT and memory Typing)]
      */
     uint64_t ignore_pat                                              : 1;
-#define EPDE_2MB_IGNORE_PAT_BIT                                      6
-#define EPDE_2MB_IGNORE_PAT_FLAG                                     0x40
-#define EPDE_2MB_IGNORE_PAT_MASK                                     0x01
-#define EPDE_2MB_IGNORE_PAT(_)                                       (((_) >> 6) & 0x01)
+#define EPT_PDE_2MB_IGNORE_PAT_BIT                                   6
+#define EPT_PDE_2MB_IGNORE_PAT_FLAG                                  0x40
+#define EPT_PDE_2MB_IGNORE_PAT_MASK                                  0x01
+#define EPT_PDE_2MB_IGNORE_PAT(_)                                    (((_) >> 6) & 0x01)
 
     /**
      * [Bit 7] Must be 1 (otherwise, this entry references an EPT page table).
      */
     uint64_t large_page                                              : 1;
-#define EPDE_2MB_LARGE_PAGE_BIT                                      7
-#define EPDE_2MB_LARGE_PAGE_FLAG                                     0x80
-#define EPDE_2MB_LARGE_PAGE_MASK                                     0x01
-#define EPDE_2MB_LARGE_PAGE(_)                                       (((_) >> 7) & 0x01)
+#define EPT_PDE_2MB_LARGE_PAGE_BIT                                   7
+#define EPT_PDE_2MB_LARGE_PAGE_FLAG                                  0x80
+#define EPT_PDE_2MB_LARGE_PAGE_MASK                                  0x01
+#define EPT_PDE_2MB_LARGE_PAGE(_)                                    (((_) >> 7) & 0x01)
 
     /**
      * [Bit 8] If bit 6 of EPTP is 1, accessed flag for EPT; indicates whether software has accessed the 2-MByte page
@@ -18617,10 +19288,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     uint64_t accessed                                                : 1;
-#define EPDE_2MB_ACCESSED_BIT                                        8
-#define EPDE_2MB_ACCESSED_FLAG                                       0x100
-#define EPDE_2MB_ACCESSED_MASK                                       0x01
-#define EPDE_2MB_ACCESSED(_)                                         (((_) >> 8) & 0x01)
+#define EPT_PDE_2MB_ACCESSED_BIT                                     8
+#define EPT_PDE_2MB_ACCESSED_FLAG                                    0x100
+#define EPT_PDE_2MB_ACCESSED_MASK                                    0x01
+#define EPT_PDE_2MB_ACCESSED(_)                                      (((_) >> 8) & 0x01)
 
     /**
      * [Bit 9] If bit 6 of EPTP is 1, dirty flag for EPT; indicates whether software has written to the 2-MByte page referenced
@@ -18629,10 +19300,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     uint64_t dirty                                                   : 1;
-#define EPDE_2MB_DIRTY_BIT                                           9
-#define EPDE_2MB_DIRTY_FLAG                                          0x200
-#define EPDE_2MB_DIRTY_MASK                                          0x01
-#define EPDE_2MB_DIRTY(_)                                            (((_) >> 9) & 0x01)
+#define EPT_PDE_2MB_DIRTY_BIT                                        9
+#define EPT_PDE_2MB_DIRTY_FLAG                                       0x200
+#define EPT_PDE_2MB_DIRTY_MASK                                       0x01
+#define EPT_PDE_2MB_DIRTY(_)                                         (((_) >> 9) & 0x01)
 
     /**
      * [Bit 10] Execute access for user-mode linear addresses. If the "mode-based execute control for EPT" VM-execution control
@@ -18640,20 +19311,20 @@ typedef union
      * by this entry. If that control is 0, this bit is ignored.
      */
     uint64_t user_mode_execute                                       : 1;
-#define EPDE_2MB_USER_MODE_EXECUTE_BIT                               10
-#define EPDE_2MB_USER_MODE_EXECUTE_FLAG                              0x400
-#define EPDE_2MB_USER_MODE_EXECUTE_MASK                              0x01
-#define EPDE_2MB_USER_MODE_EXECUTE(_)                                (((_) >> 10) & 0x01)
+#define EPT_PDE_2MB_USER_MODE_EXECUTE_BIT                            10
+#define EPT_PDE_2MB_USER_MODE_EXECUTE_FLAG                           0x400
+#define EPT_PDE_2MB_USER_MODE_EXECUTE_MASK                           0x01
+#define EPT_PDE_2MB_USER_MODE_EXECUTE(_)                             (((_) >> 10) & 0x01)
     uint64_t reserved1                                               : 10;
 
     /**
      * [Bits 47:21] Physical address of 4-KByte aligned EPT page-directory-pointer table referenced by this entry.
      */
     uint64_t page_frame_number                                       : 27;
-#define EPDE_2MB_PAGE_FRAME_NUMBER_BIT                               21
-#define EPDE_2MB_PAGE_FRAME_NUMBER_FLAG                              0xFFFFFFE00000
-#define EPDE_2MB_PAGE_FRAME_NUMBER_MASK                              0x7FFFFFF
-#define EPDE_2MB_PAGE_FRAME_NUMBER(_)                                (((_) >> 21) & 0x7FFFFFF)
+#define EPT_PDE_2MB_PAGE_FRAME_NUMBER_BIT                            21
+#define EPT_PDE_2MB_PAGE_FRAME_NUMBER_FLAG                           0xFFFFFFE00000
+#define EPT_PDE_2MB_PAGE_FRAME_NUMBER_MASK                           0x7FFFFFF
+#define EPT_PDE_2MB_PAGE_FRAME_NUMBER(_)                             (((_) >> 21) & 0x7FFFFFF)
     uint64_t reserved2                                               : 15;
 
     /**
@@ -18664,14 +19335,14 @@ typedef union
      * @see Vol3C[25.5.6.1(Convertible EPT Violations)]
      */
     uint64_t suppress_ve                                             : 1;
-#define EPDE_2MB_SUPPRESS_VE_BIT                                     63
-#define EPDE_2MB_SUPPRESS_VE_FLAG                                    0x8000000000000000
-#define EPDE_2MB_SUPPRESS_VE_MASK                                    0x01
-#define EPDE_2MB_SUPPRESS_VE(_)                                      (((_) >> 63) & 0x01)
+#define EPT_PDE_2MB_SUPPRESS_VE_BIT                                  63
+#define EPT_PDE_2MB_SUPPRESS_VE_FLAG                                 0x8000000000000000
+#define EPT_PDE_2MB_SUPPRESS_VE_MASK                                 0x01
+#define EPT_PDE_2MB_SUPPRESS_VE(_)                                   (((_) >> 63) & 0x01)
   };
 
   uint64_t flags;
-} epde_2mb;
+} ept_pde_2mb;
 
 /**
  * @brief Format of an EPT Page-Directory Entry (PDE) that References an EPT Page Table
@@ -18684,19 +19355,19 @@ typedef union
      * [Bit 0] Read access; indicates whether reads are allowed from the 2-MByte region controlled by this entry.
      */
     uint64_t read_access                                             : 1;
-#define EPDE_READ_ACCESS_BIT                                         0
-#define EPDE_READ_ACCESS_FLAG                                        0x01
-#define EPDE_READ_ACCESS_MASK                                        0x01
-#define EPDE_READ_ACCESS(_)                                          (((_) >> 0) & 0x01)
+#define EPT_PDE_READ_ACCESS_BIT                                      0
+#define EPT_PDE_READ_ACCESS_FLAG                                     0x01
+#define EPT_PDE_READ_ACCESS_MASK                                     0x01
+#define EPT_PDE_READ_ACCESS(_)                                       (((_) >> 0) & 0x01)
 
     /**
      * [Bit 1] Write access; indicates whether writes are allowed from the 2-MByte region controlled by this entry.
      */
     uint64_t write_access                                            : 1;
-#define EPDE_WRITE_ACCESS_BIT                                        1
-#define EPDE_WRITE_ACCESS_FLAG                                       0x02
-#define EPDE_WRITE_ACCESS_MASK                                       0x01
-#define EPDE_WRITE_ACCESS(_)                                         (((_) >> 1) & 0x01)
+#define EPT_PDE_WRITE_ACCESS_BIT                                     1
+#define EPT_PDE_WRITE_ACCESS_FLAG                                    0x02
+#define EPT_PDE_WRITE_ACCESS_MASK                                    0x01
+#define EPT_PDE_WRITE_ACCESS(_)                                      (((_) >> 1) & 0x01)
 
     /**
      * [Bit 2] If the "mode-based execute control for EPT" VM-execution control is 0, execute access; indicates whether
@@ -18705,10 +19376,10 @@ typedef union
      * allowed from supervisor-mode linear addresses in the 2-MByte region controlled by this entry.
      */
     uint64_t execute_access                                          : 1;
-#define EPDE_EXECUTE_ACCESS_BIT                                      2
-#define EPDE_EXECUTE_ACCESS_FLAG                                     0x04
-#define EPDE_EXECUTE_ACCESS_MASK                                     0x01
-#define EPDE_EXECUTE_ACCESS(_)                                       (((_) >> 2) & 0x01)
+#define EPT_PDE_EXECUTE_ACCESS_BIT                                   2
+#define EPT_PDE_EXECUTE_ACCESS_FLAG                                  0x04
+#define EPT_PDE_EXECUTE_ACCESS_MASK                                  0x01
+#define EPT_PDE_EXECUTE_ACCESS(_)                                    (((_) >> 2) & 0x01)
     uint64_t reserved1                                               : 5;
 
     /**
@@ -18718,10 +19389,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     uint64_t accessed                                                : 1;
-#define EPDE_ACCESSED_BIT                                            8
-#define EPDE_ACCESSED_FLAG                                           0x100
-#define EPDE_ACCESSED_MASK                                           0x01
-#define EPDE_ACCESSED(_)                                             (((_) >> 8) & 0x01)
+#define EPT_PDE_ACCESSED_BIT                                         8
+#define EPT_PDE_ACCESSED_FLAG                                        0x100
+#define EPT_PDE_ACCESSED_MASK                                        0x01
+#define EPT_PDE_ACCESSED(_)                                          (((_) >> 8) & 0x01)
     uint64_t reserved2                                               : 1;
 
     /**
@@ -18730,25 +19401,25 @@ typedef union
      * by this entry. If that control is 0, this bit is ignored.
      */
     uint64_t user_mode_execute                                       : 1;
-#define EPDE_USER_MODE_EXECUTE_BIT                                   10
-#define EPDE_USER_MODE_EXECUTE_FLAG                                  0x400
-#define EPDE_USER_MODE_EXECUTE_MASK                                  0x01
-#define EPDE_USER_MODE_EXECUTE(_)                                    (((_) >> 10) & 0x01)
+#define EPT_PDE_USER_MODE_EXECUTE_BIT                                10
+#define EPT_PDE_USER_MODE_EXECUTE_FLAG                               0x400
+#define EPT_PDE_USER_MODE_EXECUTE_MASK                               0x01
+#define EPT_PDE_USER_MODE_EXECUTE(_)                                 (((_) >> 10) & 0x01)
     uint64_t reserved3                                               : 1;
 
     /**
      * [Bits 47:12] Physical address of 4-KByte aligned EPT page table referenced by this entry.
      */
     uint64_t page_frame_number                                       : 36;
-#define EPDE_PAGE_FRAME_NUMBER_BIT                                   12
-#define EPDE_PAGE_FRAME_NUMBER_FLAG                                  0xFFFFFFFFF000
-#define EPDE_PAGE_FRAME_NUMBER_MASK                                  0xFFFFFFFFF
-#define EPDE_PAGE_FRAME_NUMBER(_)                                    (((_) >> 12) & 0xFFFFFFFFF)
+#define EPT_PDE_PAGE_FRAME_NUMBER_BIT                                12
+#define EPT_PDE_PAGE_FRAME_NUMBER_FLAG                               0xFFFFFFFFF000
+#define EPT_PDE_PAGE_FRAME_NUMBER_MASK                               0xFFFFFFFFF
+#define EPT_PDE_PAGE_FRAME_NUMBER(_)                                 (((_) >> 12) & 0xFFFFFFFFF)
     uint64_t reserved4                                               : 16;
   };
 
   uint64_t flags;
-} epde;
+} ept_pde;
 
 /**
  * @brief Format of an EPT Page-Table Entry that Maps a 4-KByte Page
@@ -18761,19 +19432,19 @@ typedef union
      * [Bit 0] Read access; indicates whether reads are allowed from the 4-KByte page referenced by this entry.
      */
     uint64_t read_access                                             : 1;
-#define EPTE_READ_ACCESS_BIT                                         0
-#define EPTE_READ_ACCESS_FLAG                                        0x01
-#define EPTE_READ_ACCESS_MASK                                        0x01
-#define EPTE_READ_ACCESS(_)                                          (((_) >> 0) & 0x01)
+#define EPT_PTE_READ_ACCESS_BIT                                      0
+#define EPT_PTE_READ_ACCESS_FLAG                                     0x01
+#define EPT_PTE_READ_ACCESS_MASK                                     0x01
+#define EPT_PTE_READ_ACCESS(_)                                       (((_) >> 0) & 0x01)
 
     /**
      * [Bit 1] Write access; indicates whether writes are allowed from the 4-KByte page referenced by this entry.
      */
     uint64_t write_access                                            : 1;
-#define EPTE_WRITE_ACCESS_BIT                                        1
-#define EPTE_WRITE_ACCESS_FLAG                                       0x02
-#define EPTE_WRITE_ACCESS_MASK                                       0x01
-#define EPTE_WRITE_ACCESS(_)                                         (((_) >> 1) & 0x01)
+#define EPT_PTE_WRITE_ACCESS_BIT                                     1
+#define EPT_PTE_WRITE_ACCESS_FLAG                                    0x02
+#define EPT_PTE_WRITE_ACCESS_MASK                                    0x01
+#define EPT_PTE_WRITE_ACCESS(_)                                      (((_) >> 1) & 0x01)
 
     /**
      * [Bit 2] If the "mode-based execute control for EPT" VM-execution control is 0, execute access; indicates whether
@@ -18782,10 +19453,10 @@ typedef union
      * allowed from supervisor-mode linear addresses in the 4-KByte page controlled by this entry.
      */
     uint64_t execute_access                                          : 1;
-#define EPTE_EXECUTE_ACCESS_BIT                                      2
-#define EPTE_EXECUTE_ACCESS_FLAG                                     0x04
-#define EPTE_EXECUTE_ACCESS_MASK                                     0x01
-#define EPTE_EXECUTE_ACCESS(_)                                       (((_) >> 2) & 0x01)
+#define EPT_PTE_EXECUTE_ACCESS_BIT                                   2
+#define EPT_PTE_EXECUTE_ACCESS_FLAG                                  0x04
+#define EPT_PTE_EXECUTE_ACCESS_MASK                                  0x01
+#define EPT_PTE_EXECUTE_ACCESS(_)                                    (((_) >> 2) & 0x01)
 
     /**
      * [Bits 5:3] EPT memory type for this 4-KByte page.
@@ -18793,10 +19464,10 @@ typedef union
      * @see Vol3C[28.2.6(EPT and memory Typing)]
      */
     uint64_t memory_type                                             : 3;
-#define EPTE_MEMORY_TYPE_BIT                                         3
-#define EPTE_MEMORY_TYPE_FLAG                                        0x38
-#define EPTE_MEMORY_TYPE_MASK                                        0x07
-#define EPTE_MEMORY_TYPE(_)                                          (((_) >> 3) & 0x07)
+#define EPT_PTE_MEMORY_TYPE_BIT                                      3
+#define EPT_PTE_MEMORY_TYPE_FLAG                                     0x38
+#define EPT_PTE_MEMORY_TYPE_MASK                                     0x07
+#define EPT_PTE_MEMORY_TYPE(_)                                       (((_) >> 3) & 0x07)
 
     /**
      * [Bit 6] Ignore PAT memory type for this 4-KByte page.
@@ -18804,10 +19475,10 @@ typedef union
      * @see Vol3C[28.2.6(EPT and memory Typing)]
      */
     uint64_t ignore_pat                                              : 1;
-#define EPTE_IGNORE_PAT_BIT                                          6
-#define EPTE_IGNORE_PAT_FLAG                                         0x40
-#define EPTE_IGNORE_PAT_MASK                                         0x01
-#define EPTE_IGNORE_PAT(_)                                           (((_) >> 6) & 0x01)
+#define EPT_PTE_IGNORE_PAT_BIT                                       6
+#define EPT_PTE_IGNORE_PAT_FLAG                                      0x40
+#define EPT_PTE_IGNORE_PAT_MASK                                      0x01
+#define EPT_PTE_IGNORE_PAT(_)                                        (((_) >> 6) & 0x01)
     uint64_t reserved1                                               : 1;
 
     /**
@@ -18817,10 +19488,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     uint64_t accessed                                                : 1;
-#define EPTE_ACCESSED_BIT                                            8
-#define EPTE_ACCESSED_FLAG                                           0x100
-#define EPTE_ACCESSED_MASK                                           0x01
-#define EPTE_ACCESSED(_)                                             (((_) >> 8) & 0x01)
+#define EPT_PTE_ACCESSED_BIT                                         8
+#define EPT_PTE_ACCESSED_FLAG                                        0x100
+#define EPT_PTE_ACCESSED_MASK                                        0x01
+#define EPT_PTE_ACCESSED(_)                                          (((_) >> 8) & 0x01)
 
     /**
      * [Bit 9] If bit 6 of EPTP is 1, dirty flag for EPT; indicates whether software has written to the 4-KByte page referenced
@@ -18829,10 +19500,10 @@ typedef union
      * @see Vol3C[28.2.4(Accessed and Dirty Flags for EPT)]
      */
     uint64_t dirty                                                   : 1;
-#define EPTE_DIRTY_BIT                                               9
-#define EPTE_DIRTY_FLAG                                              0x200
-#define EPTE_DIRTY_MASK                                              0x01
-#define EPTE_DIRTY(_)                                                (((_) >> 9) & 0x01)
+#define EPT_PTE_DIRTY_BIT                                            9
+#define EPT_PTE_DIRTY_FLAG                                           0x200
+#define EPT_PTE_DIRTY_MASK                                           0x01
+#define EPT_PTE_DIRTY(_)                                             (((_) >> 9) & 0x01)
 
     /**
      * [Bit 10] Execute access for user-mode linear addresses. If the "mode-based execute control for EPT" VM-execution control
@@ -18840,20 +19511,20 @@ typedef union
      * by this entry. If that control is 0, this bit is ignored.
      */
     uint64_t user_mode_execute                                       : 1;
-#define EPTE_USER_MODE_EXECUTE_BIT                                   10
-#define EPTE_USER_MODE_EXECUTE_FLAG                                  0x400
-#define EPTE_USER_MODE_EXECUTE_MASK                                  0x01
-#define EPTE_USER_MODE_EXECUTE(_)                                    (((_) >> 10) & 0x01)
+#define EPT_PTE_USER_MODE_EXECUTE_BIT                                10
+#define EPT_PTE_USER_MODE_EXECUTE_FLAG                               0x400
+#define EPT_PTE_USER_MODE_EXECUTE_MASK                               0x01
+#define EPT_PTE_USER_MODE_EXECUTE(_)                                 (((_) >> 10) & 0x01)
     uint64_t reserved2                                               : 1;
 
     /**
      * [Bits 47:12] Physical address of the 4-KByte page referenced by this entry.
      */
     uint64_t page_frame_number                                       : 36;
-#define EPTE_PAGE_FRAME_NUMBER_BIT                                   12
-#define EPTE_PAGE_FRAME_NUMBER_FLAG                                  0xFFFFFFFFF000
-#define EPTE_PAGE_FRAME_NUMBER_MASK                                  0xFFFFFFFFF
-#define EPTE_PAGE_FRAME_NUMBER(_)                                    (((_) >> 12) & 0xFFFFFFFFF)
+#define EPT_PTE_PAGE_FRAME_NUMBER_BIT                                12
+#define EPT_PTE_PAGE_FRAME_NUMBER_FLAG                               0xFFFFFFFFF000
+#define EPT_PTE_PAGE_FRAME_NUMBER_MASK                               0xFFFFFFFFF
+#define EPT_PTE_PAGE_FRAME_NUMBER(_)                                 (((_) >> 12) & 0xFFFFFFFFF)
     uint64_t reserved3                                               : 15;
 
     /**
@@ -18864,14 +19535,14 @@ typedef union
      * @see Vol3C[25.5.6.1(Convertible EPT Violations)]
      */
     uint64_t suppress_ve                                             : 1;
-#define EPTE_SUPPRESS_VE_BIT                                         63
-#define EPTE_SUPPRESS_VE_FLAG                                        0x8000000000000000
-#define EPTE_SUPPRESS_VE_MASK                                        0x01
-#define EPTE_SUPPRESS_VE(_)                                          (((_) >> 63) & 0x01)
+#define EPT_PTE_SUPPRESS_VE_BIT                                      63
+#define EPT_PTE_SUPPRESS_VE_FLAG                                     0x8000000000000000
+#define EPT_PTE_SUPPRESS_VE_MASK                                     0x01
+#define EPT_PTE_SUPPRESS_VE(_)                                       (((_) >> 63) & 0x01)
   };
 
   uint64_t flags;
-} epte;
+} ept_pte;
 
 /**
  * @brief Format of a common EPT Entry
@@ -19539,9 +20210,24 @@ typedef union
 #define VMCS_CTRL_ENCLS_EXITING_BITMAP                               0x0000202E
 
 /**
+ * Sub-page-permission-table pointer.
+ */
+#define VMCS_CTRL_SUB_PAGE_PERMISSION_TABLE_POINTER                  0x00002030
+
+/**
  * TSC multiplier.
  */
 #define VMCS_CTRL_TSC_MULTIPLIER                                     0x00002032
+
+/**
+ * Tertiary processor-based VM-execution controls.
+ */
+#define VMCS_CTRL_TERTIARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS     0x00002034
+
+/**
+ * ENCLV-exiting bitmap.
+ */
+#define VMCS_CTRL_ENCLV_EXITING_BITMAP                               0x00002036
 /**
  * @}
  */
@@ -19622,6 +20308,11 @@ typedef union
  * Guest IA32_RTIT_CTL.
  */
 #define VMCS_GUEST_RTIT_CTL                                          0x00002814
+
+/**
+ * Guest IA32_PKRS
+ */
+#define VMCS_GUEST_PKRS                                              0x00002818
 /**
  * @}
  */
@@ -19647,6 +20338,11 @@ typedef union
  * Host IA32_PERF_GLOBAL_CTRL.
  */
 #define VMCS_HOST_PERF_GLOBAL_CTRL                                   0x00002C04
+
+/**
+ * Host IA32_PKRS
+ */
+#define VMCS_HOST_PKRS                                               0x00002C06
 /**
  * @}
  */

--- a/out/ia32_compact.h
+++ b/out/ia32_compact.h
@@ -58,17 +58,19 @@ typedef union {
     uint64_t os_fxsave_fxrstor_support                               : 1;
     uint64_t os_xmm_exception_support                                : 1;
     uint64_t usermode_instruction_prevention                         : 1;
-    uint64_t reserved_1                                              : 1;
+    uint64_t linear_addresses_57_bit                                 : 1;
     uint64_t vmx_enable                                              : 1;
     uint64_t smx_enable                                              : 1;
-    uint64_t reserved_2                                              : 1;
+    uint64_t reserved_1                                              : 1;
     uint64_t fsgsbase_enable                                         : 1;
     uint64_t pcid_enable                                             : 1;
     uint64_t os_xsave                                                : 1;
-    uint64_t reserved_3                                              : 1;
+    uint64_t key_locker_enable                                       : 1;
     uint64_t smep_enable                                             : 1;
     uint64_t smap_enable                                             : 1;
     uint64_t protection_key_enable                                   : 1;
+    uint64_t control_flow_enforcement_enable                         : 1;
+    uint64_t protection_key_for_supervisor_mode_enable               : 1;
   };
 
   uint64_t flags;
@@ -462,11 +464,29 @@ typedef struct {
       uint32_t umip                                                  : 1;
       uint32_t pku                                                   : 1;
       uint32_t ospke                                                 : 1;
-      uint32_t reserved_1                                            : 12;
+      uint32_t waitpkg                                               : 1;
+      uint32_t avx512_vbmi2                                          : 1;
+      uint32_t cet_ss                                                : 1;
+      uint32_t gfni                                                  : 1;
+      uint32_t vaes                                                  : 1;
+      uint32_t vpclmulqdq                                            : 1;
+      uint32_t avx512_vnni                                           : 1;
+      uint32_t avx512_bitalg                                         : 1;
+      uint32_t tme_en                                                : 1;
+      uint32_t avx512_vpopcntdq                                      : 1;
+      uint32_t reserved_1                                            : 1;
+      uint32_t la57                                                  : 1;
       uint32_t mawau                                                 : 5;
       uint32_t rdpid                                                 : 1;
-      uint32_t reserved_2                                            : 7;
+      uint32_t kl                                                    : 1;
+      uint32_t reserved_2                                            : 1;
+      uint32_t cldemote                                              : 1;
+      uint32_t reserved_3                                            : 1;
+      uint32_t movdiri                                               : 1;
+      uint32_t movdir64b                                             : 1;
+      uint32_t reserved_4                                            : 1;
       uint32_t sgx_lc                                                : 1;
+      uint32_t pks                                                   : 1;
     };
 
     uint32_t flags;
@@ -474,7 +494,27 @@ typedef struct {
 
   union {
     struct {
-      uint32_t reserved                                              : 32;
+      uint32_t reserved_1                                            : 2;
+      uint32_t avx512_4vnniw                                         : 1;
+      uint32_t avx512_4fmaps                                         : 1;
+      uint32_t fast_short_rep_mov                                    : 1;
+      uint32_t reserved_2                                            : 3;
+      uint32_t avx512_vp2intersect                                   : 1;
+      uint32_t reserved_3                                            : 1;
+      uint32_t md_clear                                              : 1;
+      uint32_t reserved_4                                            : 4;
+      uint32_t hybrid                                                : 1;
+      uint32_t reserved_5                                            : 2;
+      uint32_t pconfig                                               : 1;
+      uint32_t reserved_6                                            : 1;
+      uint32_t cet_ibt                                               : 1;
+      uint32_t reserved_7                                            : 5;
+      uint32_t ibrs_ibpb                                             : 1;
+      uint32_t stibp                                                 : 1;
+      uint32_t l1d_flush                                             : 1;
+      uint32_t ia32_arch_capabilities                                : 1;
+      uint32_t ia32_core_capabilities                                : 1;
+      uint32_t ssbd                                                  : 1;
     };
 
     uint32_t flags;
@@ -2847,6 +2887,10 @@ typedef union {
     uint64_t save_vmx_preemption_timer_value                         : 1;
     uint64_t clear_ia32_bndcfgs                                      : 1;
     uint64_t conceal_vmx_from_pt                                     : 1;
+    uint64_t clear_ia32_rtit_ctl                                     : 1;
+    uint64_t reserved_6                                              : 2;
+    uint64_t load_ia32_cet_state                                     : 1;
+    uint64_t load_ia32_pkrs                                          : 1;
   };
 
   uint64_t flags;
@@ -2870,6 +2914,8 @@ typedef union {
     uint64_t load_ia32_rtit_ctl                                      : 1;
     uint64_t reserved_4                                              : 1;
     uint64_t load_cet_state                                          : 1;
+    uint64_t reserved_5                                              : 1;
+    uint64_t load_ia32_pkrs                                          : 1;
   };
 
   uint64_t flags;
@@ -3178,6 +3224,47 @@ typedef union {
  */
 
 #define IA32_DS_AREA                                                 0x00000600
+#define IA32_U_CET                                                   0x000006A0
+typedef union {
+  struct {
+    uint64_t sh_stk_en                                               : 1;
+    uint64_t wr_shstk_en                                             : 1;
+    uint64_t endbr_en                                                : 1;
+    uint64_t leg_iw_en                                               : 1;
+    uint64_t no_track_en                                             : 1;
+    uint64_t suppress_dis                                            : 1;
+    uint64_t reserved_1                                              : 4;
+    uint64_t suppress                                                : 1;
+    uint64_t tracker                                                 : 1;
+    uint64_t eb_leg_bitmap_base                                      : 52;
+  };
+
+  uint64_t flags;
+} ia32_u_cet_register;
+
+#define IA32_S_CET                                                   0x000006A2
+typedef union {
+  struct {
+    uint64_t sh_stk_en                                               : 1;
+    uint64_t wr_shstk_en                                             : 1;
+    uint64_t endbr_en                                                : 1;
+    uint64_t leg_iw_en                                               : 1;
+    uint64_t no_track_en                                             : 1;
+    uint64_t suppress_dis                                            : 1;
+    uint64_t reserved_1                                              : 4;
+    uint64_t suppress                                                : 1;
+    uint64_t tracker                                                 : 1;
+    uint64_t eb_leg_bitmap_base                                      : 52;
+  };
+
+  uint64_t flags;
+} ia32_s_cet_register;
+
+#define IA32_PL0_SSP                                                 0x000006A4
+#define IA32_PL1_SSP                                                 0x000006A5
+#define IA32_PL2_SSP                                                 0x000006A6
+#define IA32_PL3_SSP                                                 0x000006A7
+#define IA32_INTERRUPT_SSP_TABLE_ADDR                                0x000006A8
 #define IA32_TSC_DEADLINE                                            0x000006E0
 #define IA32_PM_ENABLE                                               0x00000770
 typedef union {
@@ -4421,7 +4508,7 @@ typedef union {
   };
 
   uint64_t flags;
-} ept_pdpte_1gb;
+} epdpte_1gb;
 
 typedef union {
   struct {
@@ -4437,7 +4524,7 @@ typedef union {
   };
 
   uint64_t flags;
-} ept_pdpte;
+} epdpte;
 
 typedef union {
   struct {
@@ -4457,7 +4544,7 @@ typedef union {
   };
 
   uint64_t flags;
-} ept_pde_2mb;
+} epde_2mb;
 
 typedef union {
   struct {
@@ -4473,7 +4560,7 @@ typedef union {
   };
 
   uint64_t flags;
-} ept_pde;
+} epde;
 
 typedef union {
   struct {
@@ -4493,7 +4580,7 @@ typedef union {
   };
 
   uint64_t flags;
-} ept_pte;
+} epte;
 
 typedef union {
   struct {
@@ -4695,7 +4782,10 @@ typedef union {
 #define VMCS_CTRL_VIRTXCPT_INFO_ADDR                                 0x0000202A
 #define VMCS_CTRL_XSS_EXITING_BITMAP                                 0x0000202C
 #define VMCS_CTRL_ENCLS_EXITING_BITMAP                               0x0000202E
+#define VMCS_CTRL_SPP_TABLE_POINTER                                  0x00002030
 #define VMCS_CTRL_TSC_MULTIPLIER                                     0x00002032
+#define VMCS_CTRL_PROC_EXEC3                                         0x00002034
+#define VMCS_CTRL_ENCLV_EXITING_BITMAP                               0x00002036
 /**
  * @}
  */
@@ -4726,6 +4816,7 @@ typedef union {
 #define VMCS_GUEST_PDPTE3                                            0x00002810
 #define VMCS_GUEST_BNDCFGS                                           0x00002812
 #define VMCS_GUEST_RTIT_CTL                                          0x00002814
+#define VMCS_GUEST_PKRS                                              0x00002818
 /**
  * @}
  */
@@ -4738,6 +4829,7 @@ typedef union {
 #define VMCS_HOST_PAT                                                0x00002C00
 #define VMCS_HOST_EFER                                               0x00002C02
 #define VMCS_HOST_PERF_GLOBAL_CTRL                                   0x00002C04
+#define VMCS_HOST_PKRS                                               0x00002C06
 /**
  * @}
  */

--- a/out/ia32_defines_only.h
+++ b/out/ia32_defines_only.h
@@ -86,26 +86,32 @@ typedef union {
 #define CR4_OS_XMM_EXCEPTION_SUPPORT                                 0x400
     uint64_t usermode_instruction_prevention                         : 1;
 #define CR4_USERMODE_INSTRUCTION_PREVENTION                          0x800
-    uint64_t reserved_1                                              : 1;
+    uint64_t linear_addresses_57_bit                                 : 1;
+#define CR4_LINEAR_ADDRESSES_57_BIT                                  0x1000
     uint64_t vmx_enable                                              : 1;
 #define CR4_VMX_ENABLE                                               0x2000
     uint64_t smx_enable                                              : 1;
 #define CR4_SMX_ENABLE                                               0x4000
-    uint64_t reserved_2                                              : 1;
+    uint64_t reserved_1                                              : 1;
     uint64_t fsgsbase_enable                                         : 1;
 #define CR4_FSGSBASE_ENABLE                                          0x10000
     uint64_t pcid_enable                                             : 1;
 #define CR4_PCID_ENABLE                                              0x20000
     uint64_t os_xsave                                                : 1;
 #define CR4_OS_XSAVE                                                 0x40000
-    uint64_t reserved_3                                              : 1;
+    uint64_t key_locker_enable                                       : 1;
+#define CR4_KEY_LOCKER_ENABLE                                        0x80000
     uint64_t smep_enable                                             : 1;
 #define CR4_SMEP_ENABLE                                              0x100000
     uint64_t smap_enable                                             : 1;
 #define CR4_SMAP_ENABLE                                              0x200000
     uint64_t protection_key_enable                                   : 1;
 #define CR4_PROTECTION_KEY_ENABLE                                    0x400000
-    uint64_t reserved_4                                              : 41;
+    uint64_t control_flow_enforcement_enable                         : 1;
+#define CR4_CONTROL_FLOW_ENFORCEMENT_ENABLE                          0x800000
+    uint64_t protection_key_for_supervisor_mode_enable               : 1;
+#define CR4_PROTECTION_KEY_FOR_SUPERVISOR_MODE_ENABLE                0x1000000
+    uint64_t reserved_2                                              : 39;
   };
 
   uint64_t Flags;
@@ -690,15 +696,48 @@ typedef struct {
 #define CPUID_ECX_PKU                                                0x08
       uint32_t ospke                                                 : 1;
 #define CPUID_ECX_OSPKE                                              0x10
-      uint32_t reserved_1                                            : 12;
+      uint32_t waitpkg                                               : 1;
+#define CPUID_ECX_WAITPKG                                            0x20
+      uint32_t avx512_vbmi2                                          : 1;
+#define CPUID_ECX_AVX512_VBMI2                                       0x40
+      uint32_t cet_ss                                                : 1;
+#define CPUID_ECX_CET_SS                                             0x80
+      uint32_t gfni                                                  : 1;
+#define CPUID_ECX_GFNI                                               0x100
+      uint32_t vaes                                                  : 1;
+#define CPUID_ECX_VAES                                               0x200
+      uint32_t vpclmulqdq                                            : 1;
+#define CPUID_ECX_VPCLMULQDQ                                         0x400
+      uint32_t avx512_vnni                                           : 1;
+#define CPUID_ECX_AVX512_VNNI                                        0x800
+      uint32_t avx512_bitalg                                         : 1;
+#define CPUID_ECX_AVX512_BITALG                                      0x1000
+      uint32_t tme_en                                                : 1;
+#define CPUID_ECX_TME_EN                                             0x2000
+      uint32_t avx512_vpopcntdq                                      : 1;
+#define CPUID_ECX_AVX512_VPOPCNTDQ                                   0x4000
+      uint32_t reserved_1                                            : 1;
+      uint32_t la57                                                  : 1;
+#define CPUID_ECX_LA57                                               0x10000
       uint32_t mawau                                                 : 5;
 #define CPUID_ECX_MAWAU                                              0x3E0000
       uint32_t rdpid                                                 : 1;
 #define CPUID_ECX_RDPID                                              0x400000
-      uint32_t reserved_2                                            : 7;
+      uint32_t kl                                                    : 1;
+#define CPUID_ECX_KL                                                 0x800000
+      uint32_t reserved_2                                            : 1;
+      uint32_t cldemote                                              : 1;
+#define CPUID_ECX_CLDEMOTE                                           0x2000000
+      uint32_t reserved_3                                            : 1;
+      uint32_t movdiri                                               : 1;
+#define CPUID_ECX_MOVDIRI                                            0x8000000
+      uint32_t movdir64b                                             : 1;
+#define CPUID_ECX_MOVDIR64B                                          0x10000000
+      uint32_t reserved_4                                            : 1;
       uint32_t sgx_lc                                                : 1;
 #define CPUID_ECX_SGX_LC                                             0x40000000
-      uint32_t reserved_3                                            : 1;
+      uint32_t pks                                                   : 1;
+#define CPUID_ECX_PKS                                                0x80000000
     };
 
     uint32_t Flags;
@@ -706,8 +745,41 @@ typedef struct {
 
   union {
     struct {
-      uint32_t reserved                                              : 32;
-#define CPUID_EDX_RESERVED                                           0xFFFFFFFF
+      uint32_t reserved_1                                            : 2;
+      uint32_t avx512_4vnniw                                         : 1;
+#define CPUID_EDX_AVX512_4VNNIW                                      0x04
+      uint32_t avx512_4fmaps                                         : 1;
+#define CPUID_EDX_AVX512_4FMAPS                                      0x08
+      uint32_t fast_short_rep_mov                                    : 1;
+#define CPUID_EDX_FAST_SHORT_REP_MOV                                 0x10
+      uint32_t reserved_2                                            : 3;
+      uint32_t avx512_vp2intersect                                   : 1;
+#define CPUID_EDX_AVX512_VP2INTERSECT                                0x100
+      uint32_t reserved_3                                            : 1;
+      uint32_t md_clear                                              : 1;
+#define CPUID_EDX_MD_CLEAR                                           0x400
+      uint32_t reserved_4                                            : 4;
+      uint32_t hybrid                                                : 1;
+#define CPUID_EDX_HYBRID                                             0x8000
+      uint32_t reserved_5                                            : 2;
+      uint32_t pconfig                                               : 1;
+#define CPUID_EDX_PCONFIG                                            0x40000
+      uint32_t reserved_6                                            : 1;
+      uint32_t cet_ibt                                               : 1;
+#define CPUID_EDX_CET_IBT                                            0x100000
+      uint32_t reserved_7                                            : 5;
+      uint32_t ibrs_ibpb                                             : 1;
+#define CPUID_EDX_IBRS_IBPB                                          0x4000000
+      uint32_t stibp                                                 : 1;
+#define CPUID_EDX_STIBP                                              0x8000000
+      uint32_t l1d_flush                                             : 1;
+#define CPUID_EDX_L1D_FLUSH                                          0x10000000
+      uint32_t ia32_arch_capabilities                                : 1;
+#define CPUID_EDX_IA32_ARCH_CAPABILITIES                             0x20000000
+      uint32_t ia32_core_capabilities                                : 1;
+#define CPUID_EDX_IA32_CORE_CAPABILITIES                             0x40000000
+      uint32_t ssbd                                                  : 1;
+#define CPUID_EDX_SSBD                                               0x80000000
     };
 
     uint32_t Flags;
@@ -3609,7 +3681,14 @@ typedef union {
 #define IA32_VMX_EXIT_CTLS_CLEAR_IA32_BNDCFGS                        0x800000
     uint64_t conceal_vmx_from_pt                                     : 1;
 #define IA32_VMX_EXIT_CTLS_CONCEAL_VMX_FROM_PT                       0x1000000
-    uint64_t reserved_6                                              : 39;
+    uint64_t clear_ia32_rtit_ctl                                     : 1;
+#define IA32_VMX_EXIT_CTLS_CLEAR_IA32_RTIT_CTL                       0x2000000
+    uint64_t reserved_6                                              : 2;
+    uint64_t load_ia32_cet_state                                     : 1;
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_CET_STATE                       0x10000000
+    uint64_t load_ia32_pkrs                                          : 1;
+#define IA32_VMX_EXIT_CTLS_LOAD_IA32_PKRS                            0x20000000
+    uint64_t reserved_7                                              : 34;
   };
 
   uint64_t Flags;
@@ -3644,7 +3723,10 @@ typedef union {
     uint64_t reserved_4                                              : 1;
     uint64_t load_cet_state                                          : 1;
 #define IA32_VMX_ENTRY_CTLS_LOAD_CET_STATE                           0x100000
-    uint64_t reserved_5                                              : 43;
+    uint64_t reserved_5                                              : 1;
+    uint64_t load_ia32_pkrs                                          : 1;
+#define IA32_VMX_ENTRY_CTLS_LOAD_IA32_PKRS                           0x400000
+    uint64_t reserved_6                                              : 41;
   };
 
   uint64_t Flags;
@@ -4063,6 +4145,65 @@ typedef union {
  */
 
 #define IA32_DS_AREA                                                 0x00000600
+#define IA32_U_CET                                                   0x000006A0
+typedef union {
+  struct {
+    uint64_t sh_stk_en                                               : 1;
+#define IA32_U_CET_SH_STK_EN                                         0x01
+    uint64_t wr_shstk_en                                             : 1;
+#define IA32_U_CET_WR_SHSTK_EN                                       0x02
+    uint64_t endbr_en                                                : 1;
+#define IA32_U_CET_ENDBR_EN                                          0x04
+    uint64_t leg_iw_en                                               : 1;
+#define IA32_U_CET_LEG_IW_EN                                         0x08
+    uint64_t no_track_en                                             : 1;
+#define IA32_U_CET_NO_TRACK_EN                                       0x10
+    uint64_t suppress_dis                                            : 1;
+#define IA32_U_CET_SUPPRESS_DIS                                      0x20
+    uint64_t reserved_1                                              : 4;
+    uint64_t suppress                                                : 1;
+#define IA32_U_CET_SUPPRESS                                          0x400
+    uint64_t tracker                                                 : 1;
+#define IA32_U_CET_TRACKER                                           0x800
+    uint64_t eb_leg_bitmap_base                                      : 52;
+#define IA32_U_CET_EB_LEG_BITMAP_BASE                                0xFFFFFFFFFFFFF000
+  };
+
+  uint64_t Flags;
+} ia32_u_cet_register;
+
+#define IA32_S_CET                                                   0x000006A2
+typedef union {
+  struct {
+    uint64_t sh_stk_en                                               : 1;
+#define IA32_S_CET_SH_STK_EN                                         0x01
+    uint64_t wr_shstk_en                                             : 1;
+#define IA32_S_CET_WR_SHSTK_EN                                       0x02
+    uint64_t endbr_en                                                : 1;
+#define IA32_S_CET_ENDBR_EN                                          0x04
+    uint64_t leg_iw_en                                               : 1;
+#define IA32_S_CET_LEG_IW_EN                                         0x08
+    uint64_t no_track_en                                             : 1;
+#define IA32_S_CET_NO_TRACK_EN                                       0x10
+    uint64_t suppress_dis                                            : 1;
+#define IA32_S_CET_SUPPRESS_DIS                                      0x20
+    uint64_t reserved_1                                              : 4;
+    uint64_t suppress                                                : 1;
+#define IA32_S_CET_SUPPRESS                                          0x400
+    uint64_t tracker                                                 : 1;
+#define IA32_S_CET_TRACKER                                           0x800
+    uint64_t eb_leg_bitmap_base                                      : 52;
+#define IA32_S_CET_EB_LEG_BITMAP_BASE                                0xFFFFFFFFFFFFF000
+  };
+
+  uint64_t Flags;
+} ia32_s_cet_register;
+
+#define IA32_PL0_SSP                                                 0x000006A4
+#define IA32_PL1_SSP                                                 0x000006A5
+#define IA32_PL2_SSP                                                 0x000006A6
+#define IA32_PL3_SSP                                                 0x000006A7
+#define IA32_INTERRUPT_SSP_TABLE_ADDR                                0x000006A8
 #define IA32_TSC_DEADLINE                                            0x000006E0
 #define IA32_PM_ENABLE                                               0x00000770
 typedef union {
@@ -5651,140 +5792,140 @@ typedef union {
 typedef union {
   struct {
     uint64_t read_access                                             : 1;
-#define EPT_PDPTE_1GB_READ_ACCESS                                    0x01
+#define EPDPTE_1GB_READ_ACCESS                                       0x01
     uint64_t write_access                                            : 1;
-#define EPT_PDPTE_1GB_WRITE_ACCESS                                   0x02
+#define EPDPTE_1GB_WRITE_ACCESS                                      0x02
     uint64_t execute_access                                          : 1;
-#define EPT_PDPTE_1GB_EXECUTE_ACCESS                                 0x04
+#define EPDPTE_1GB_EXECUTE_ACCESS                                    0x04
     uint64_t memory_type                                             : 3;
-#define EPT_PDPTE_1GB_MEMORY_TYPE                                    0x38
+#define EPDPTE_1GB_MEMORY_TYPE                                       0x38
     uint64_t ignore_pat                                              : 1;
-#define EPT_PDPTE_1GB_IGNORE_PAT                                     0x40
+#define EPDPTE_1GB_IGNORE_PAT                                        0x40
     uint64_t large_page                                              : 1;
-#define EPT_PDPTE_1GB_LARGE_PAGE                                     0x80
+#define EPDPTE_1GB_LARGE_PAGE                                        0x80
     uint64_t accessed                                                : 1;
-#define EPT_PDPTE_1GB_ACCESSED                                       0x100
+#define EPDPTE_1GB_ACCESSED                                          0x100
     uint64_t dirty                                                   : 1;
-#define EPT_PDPTE_1GB_DIRTY                                          0x200
+#define EPDPTE_1GB_DIRTY                                             0x200
     uint64_t user_mode_execute                                       : 1;
-#define EPT_PDPTE_1GB_USER_MODE_EXECUTE                              0x400
+#define EPDPTE_1GB_USER_MODE_EXECUTE                                 0x400
     uint64_t reserved_1                                              : 19;
     uint64_t page_frame_number                                       : 18;
-#define EPT_PDPTE_1GB_PAGE_FRAME_NUMBER                              0xFFFFC0000000
+#define EPDPTE_1GB_PAGE_FRAME_NUMBER                                 0xFFFFC0000000
     uint64_t reserved_2                                              : 15;
     uint64_t suppress_ve                                             : 1;
-#define EPT_PDPTE_1GB_SUPPRESS_VE                                    0x8000000000000000
+#define EPDPTE_1GB_SUPPRESS_VE                                       0x8000000000000000
   };
 
   uint64_t Flags;
-} ept_pdpte_1gb;
+} epdpte_1gb;
 
 typedef union {
   struct {
     uint64_t read_access                                             : 1;
-#define EPT_PDPTE_READ_ACCESS                                        0x01
+#define EPDPTE_READ_ACCESS                                           0x01
     uint64_t write_access                                            : 1;
-#define EPT_PDPTE_WRITE_ACCESS                                       0x02
+#define EPDPTE_WRITE_ACCESS                                          0x02
     uint64_t execute_access                                          : 1;
-#define EPT_PDPTE_EXECUTE_ACCESS                                     0x04
+#define EPDPTE_EXECUTE_ACCESS                                        0x04
     uint64_t reserved_1                                              : 5;
     uint64_t accessed                                                : 1;
-#define EPT_PDPTE_ACCESSED                                           0x100
+#define EPDPTE_ACCESSED                                              0x100
     uint64_t reserved_2                                              : 1;
     uint64_t user_mode_execute                                       : 1;
-#define EPT_PDPTE_USER_MODE_EXECUTE                                  0x400
+#define EPDPTE_USER_MODE_EXECUTE                                     0x400
     uint64_t reserved_3                                              : 1;
     uint64_t page_frame_number                                       : 36;
-#define EPT_PDPTE_PAGE_FRAME_NUMBER                                  0xFFFFFFFFF000
+#define EPDPTE_PAGE_FRAME_NUMBER                                     0xFFFFFFFFF000
     uint64_t reserved_4                                              : 16;
   };
 
   uint64_t Flags;
-} ept_pdpte;
+} epdpte;
 
 typedef union {
   struct {
     uint64_t read_access                                             : 1;
-#define EPT_PDE_2MB_READ_ACCESS                                      0x01
+#define EPDE_2MB_READ_ACCESS                                         0x01
     uint64_t write_access                                            : 1;
-#define EPT_PDE_2MB_WRITE_ACCESS                                     0x02
+#define EPDE_2MB_WRITE_ACCESS                                        0x02
     uint64_t execute_access                                          : 1;
-#define EPT_PDE_2MB_EXECUTE_ACCESS                                   0x04
+#define EPDE_2MB_EXECUTE_ACCESS                                      0x04
     uint64_t memory_type                                             : 3;
-#define EPT_PDE_2MB_MEMORY_TYPE                                      0x38
+#define EPDE_2MB_MEMORY_TYPE                                         0x38
     uint64_t ignore_pat                                              : 1;
-#define EPT_PDE_2MB_IGNORE_PAT                                       0x40
+#define EPDE_2MB_IGNORE_PAT                                          0x40
     uint64_t large_page                                              : 1;
-#define EPT_PDE_2MB_LARGE_PAGE                                       0x80
+#define EPDE_2MB_LARGE_PAGE                                          0x80
     uint64_t accessed                                                : 1;
-#define EPT_PDE_2MB_ACCESSED                                         0x100
+#define EPDE_2MB_ACCESSED                                            0x100
     uint64_t dirty                                                   : 1;
-#define EPT_PDE_2MB_DIRTY                                            0x200
+#define EPDE_2MB_DIRTY                                               0x200
     uint64_t user_mode_execute                                       : 1;
-#define EPT_PDE_2MB_USER_MODE_EXECUTE                                0x400
+#define EPDE_2MB_USER_MODE_EXECUTE                                   0x400
     uint64_t reserved_1                                              : 10;
     uint64_t page_frame_number                                       : 27;
-#define EPT_PDE_2MB_PAGE_FRAME_NUMBER                                0xFFFFFFE00000
+#define EPDE_2MB_PAGE_FRAME_NUMBER                                   0xFFFFFFE00000
     uint64_t reserved_2                                              : 15;
     uint64_t suppress_ve                                             : 1;
-#define EPT_PDE_2MB_SUPPRESS_VE                                      0x8000000000000000
+#define EPDE_2MB_SUPPRESS_VE                                         0x8000000000000000
   };
 
   uint64_t Flags;
-} ept_pde_2mb;
+} epde_2mb;
 
 typedef union {
   struct {
     uint64_t read_access                                             : 1;
-#define EPT_PDE_READ_ACCESS                                          0x01
+#define EPDE_READ_ACCESS                                             0x01
     uint64_t write_access                                            : 1;
-#define EPT_PDE_WRITE_ACCESS                                         0x02
+#define EPDE_WRITE_ACCESS                                            0x02
     uint64_t execute_access                                          : 1;
-#define EPT_PDE_EXECUTE_ACCESS                                       0x04
+#define EPDE_EXECUTE_ACCESS                                          0x04
     uint64_t reserved_1                                              : 5;
     uint64_t accessed                                                : 1;
-#define EPT_PDE_ACCESSED                                             0x100
+#define EPDE_ACCESSED                                                0x100
     uint64_t reserved_2                                              : 1;
     uint64_t user_mode_execute                                       : 1;
-#define EPT_PDE_USER_MODE_EXECUTE                                    0x400
+#define EPDE_USER_MODE_EXECUTE                                       0x400
     uint64_t reserved_3                                              : 1;
     uint64_t page_frame_number                                       : 36;
-#define EPT_PDE_PAGE_FRAME_NUMBER                                    0xFFFFFFFFF000
+#define EPDE_PAGE_FRAME_NUMBER                                       0xFFFFFFFFF000
     uint64_t reserved_4                                              : 16;
   };
 
   uint64_t Flags;
-} ept_pde;
+} epde;
 
 typedef union {
   struct {
     uint64_t read_access                                             : 1;
-#define EPT_PTE_READ_ACCESS                                          0x01
+#define EPTE_READ_ACCESS                                             0x01
     uint64_t write_access                                            : 1;
-#define EPT_PTE_WRITE_ACCESS                                         0x02
+#define EPTE_WRITE_ACCESS                                            0x02
     uint64_t execute_access                                          : 1;
-#define EPT_PTE_EXECUTE_ACCESS                                       0x04
+#define EPTE_EXECUTE_ACCESS                                          0x04
     uint64_t memory_type                                             : 3;
-#define EPT_PTE_MEMORY_TYPE                                          0x38
+#define EPTE_MEMORY_TYPE                                             0x38
     uint64_t ignore_pat                                              : 1;
-#define EPT_PTE_IGNORE_PAT                                           0x40
+#define EPTE_IGNORE_PAT                                              0x40
     uint64_t reserved_1                                              : 1;
     uint64_t accessed                                                : 1;
-#define EPT_PTE_ACCESSED                                             0x100
+#define EPTE_ACCESSED                                                0x100
     uint64_t dirty                                                   : 1;
-#define EPT_PTE_DIRTY                                                0x200
+#define EPTE_DIRTY                                                   0x200
     uint64_t user_mode_execute                                       : 1;
-#define EPT_PTE_USER_MODE_EXECUTE                                    0x400
+#define EPTE_USER_MODE_EXECUTE                                       0x400
     uint64_t reserved_2                                              : 1;
     uint64_t page_frame_number                                       : 36;
-#define EPT_PTE_PAGE_FRAME_NUMBER                                    0xFFFFFFFFF000
+#define EPTE_PAGE_FRAME_NUMBER                                       0xFFFFFFFFF000
     uint64_t reserved_3                                              : 15;
     uint64_t suppress_ve                                             : 1;
-#define EPT_PTE_SUPPRESS_VE                                          0x8000000000000000
+#define EPTE_SUPPRESS_VE                                             0x8000000000000000
   };
 
   uint64_t Flags;
-} ept_pte;
+} epte;
 
 typedef union {
   struct {
@@ -6005,7 +6146,10 @@ typedef union {
 #define VMCS_CTRL_VIRTXCPT_INFO_ADDR                                 0x0000202A
 #define VMCS_CTRL_XSS_EXITING_BITMAP                                 0x0000202C
 #define VMCS_CTRL_ENCLS_EXITING_BITMAP                               0x0000202E
+#define VMCS_CTRL_SPP_TABLE_POINTER                                  0x00002030
 #define VMCS_CTRL_TSC_MULTIPLIER                                     0x00002032
+#define VMCS_CTRL_PROC_EXEC3                                         0x00002034
+#define VMCS_CTRL_ENCLV_EXITING_BITMAP                               0x00002036
 /**
  * @}
  */
@@ -6036,6 +6180,7 @@ typedef union {
 #define VMCS_GUEST_PDPTE3                                            0x00002810
 #define VMCS_GUEST_BNDCFGS                                           0x00002812
 #define VMCS_GUEST_RTIT_CTL                                          0x00002814
+#define VMCS_GUEST_PKRS                                              0x00002818
 /**
  * @}
  */
@@ -6048,6 +6193,7 @@ typedef union {
 #define VMCS_HOST_PAT                                                0x00002C00
 #define VMCS_HOST_EFER                                               0x00002C02
 #define VMCS_HOST_PERF_GLOBAL_CTRL                                   0x00002C04
+#define VMCS_HOST_PKRS                                               0x00002C06
 /**
  * @}
  */

--- a/yaml/Intel/CPUID/EAX_07.yml
+++ b/yaml/Intel/CPUID/EAX_07.yml
@@ -174,6 +174,55 @@
       name: OSPKE
       description: If 1, OS has set CR4.PKE to enable protection keys (and the RDPKRU/WRPKRU instructions).
 
+    - bit: 5
+      name: WAITPKG
+      description: WAITPKG.
+
+    - bit: 6
+      name: AVX512_VBMI2
+      description: AVX512_VBMI2.
+
+    - bit: 7
+      name: CET_SS
+      description: |
+        Supports CET shadow stack features if 1. Processors that set this bit define bits
+        1:0 of the IA32_U_CET and IA32_S_CET MSRs. Enumerates support for the following MSRs:
+        IA32_INTERRUPT_SPP_TABLE_ADDR, IA32_PL3_SSP, IA32_PL2_SSP, IA32_PL1_SSP, and IA32_PL0_SSP.
+
+    - bit: 8
+      name: GFNI
+      description: GFNI.
+
+    - bit: 9
+      name: VAES
+      description: VAES.
+
+    - bit: 10
+      name: VPCLMULQDQ
+      description: VPCLMULQDQ.
+
+    - bit: 11
+      name: AVX512_VNNI
+      description: AVX512_VNNI.
+
+    - bit: 12
+      name: AVX512_BITALG
+      description: AVX512_BITALG.
+
+    - bit: 13
+      name: TME_EN
+      description: |
+        If 1, the following MSRs are supported: IA32_TME_CAPABILITY, IA32_TME_ACTIVATE,
+        IA32_TME_EXCLUDE_MASK, and IA32_TME_EXCLUDE_BASE.
+
+    - bit: 14
+      name: AVX512_VPOPCNTDQ
+      description: AVX512_VPOPCNTDQ.
+
+    - bit: 16
+      name: LA57
+      description: Supports 57-bit linear addresses and five-level paging if 1.
+
     - bit: 17-21
       name: MAWAU
       description: The value of MAWAU used by the BNDLDX and BNDSTX instructions in 64-bit mode.
@@ -182,14 +231,97 @@
       name: RDPID
       description: RDPID and IA32_TSC_AUX are available if 1.
 
+    - bit: 23
+      name: KL
+      description: KL. Supports Key Locker if 1.
+
+    - bit: 25
+      name: CLDEMOTE
+      description: Supports cache line demote if 1.
+
+    - bit: 27
+      name: MOVDIRI
+      description: Supports MOVDIRI if 1.
+
+    - bit: 28
+      name: MOVDIR64B
+      description: Supports MOVDIR64B if 1.
+
     - bit: 30
       name: SGX_LC
       description: Supports SGX Launch Configuration if 1.
+
+    - bit: 31
+      name: PKS
+      description: Supports protection keys for supervisor-mode pages if 1.
 
   - name: EDX
     type: bitfield
     size: 32
     fields:
-    - bit: 0-31
-      name: RESERVED
-      description: EDX is reserved.
+    - bit: 2
+      name: AVX512_4VNNIW
+      description: (Intel® Xeon Phi™ only.)
+
+    - bit: 3
+      name: AVX512_4FMAPS
+      description: (Intel® Xeon Phi™ only.)
+
+    - bit: 4
+      name: FAST_SHORT_REP_MOV
+      description: Fast Short REP MOV.
+
+    - bit: 8
+      name: AVX512_VP2INTERSECT
+      description: AVX512_VP2INTERSECT.
+
+    - bit: 10
+      name: MD_CLEAR
+      description: MD_CLEAR supported.
+
+    - bit: 15
+      name: HYBRID
+      description: If 1, the processor is identified as a hybrid part.
+
+    - bit: 18
+      name: PCONFIG
+      description: Supports PCONFIG if 1.
+
+    - bit: 20
+      name: CET_IBT
+      description: |
+        Supports CET indirect branch tracking features if 1. Processors that set this bit define
+        bits 5:2 and bits 63:10 of the IA32_U_CET and IA32_S_CET MSRs.
+
+    - bit: 26
+      name: IBRS_IBPB
+      description: |
+        Enumerates support for indirect branch restricted speculation (IBRS) and the indirect branch predictor barrier (IBPB). Processors that set this bit support the IA32_SPEC_CTRL MSR and the
+        IA32_PRED_CMD MSR. They allow software to set IA32_SPEC_CTRL[0] (IBRS) and IA32_PRED_CMD[0]
+        (IBPB).
+
+    - bit: 27
+      name: STIBP
+      description: |
+        Enumerates support for single thread indirect branch predictors (STIBP). Processors that set
+        this bit support the IA32_SPEC_CTRL MSR. They allow software to set IA32_SPEC_CTRL[1] (STIBP).
+
+    - bit: 28
+      name: L1D_FLUSH
+      description: |
+        Enumerates support for L1D_FLUSH. Processors that set this bit support the IA32_FLUSH_CMD
+        MSR. They allow software to set IA32_FLUSH_CMD[0] (L1D_FLUSH).
+
+    - bit: 29
+      name: IA32_ARCH_CAPABILITIES
+      description: Enumerates support for the IA32_ARCH_CAPABILITIES MSR.
+
+    - bit: 30
+      name: IA32_CORE_CAPABILITIES
+      description: Enumerates support for the IA32_CORE_CAPABILITIES MSR.
+
+    - bit: 31
+      name: SSBD
+      description: |
+        Enumerates support for Speculative Store Bypass Disable (SSBD). Processors that set this bit
+        support the IA32_SPEC_CTRL MSR. They allow software to set IA32_SPEC_CTRL[2] (SSBD).

--- a/yaml/Intel/ControlRegisters/CR4.yml
+++ b/yaml/Intel/ControlRegisters/CR4.yml
@@ -146,6 +146,16 @@
       executed if CPL > 0: SGDT, SIDT, SLDT, SMSW, and STR. An attempt at such execution causes a generalprotection
       exception (#GP).
 
+  - bit: 12
+    short_name: LA57
+    long_name: LINEAR_ADDRESSES_57_BIT
+    short_description: 57-bit Linear Addresses
+    long_description: |
+      When set in IA-32e mode, the processor uses 5-level paging to translate 57-bit linear addresses.
+      When clear in IA-32e mode, the processor uses 4-level paging to translate 48-bit linear addresses.
+      This bit cannot be modified in IA-32e mode.
+    see: Vol3C[4(PAGING)]
+
   - bit: 13
     short_name: VMXE
     long_name: VMX_ENABLE
@@ -199,6 +209,17 @@
     - Vol3A[2.6(EXTENDED CONTROL REGISTERS (INCLUDING XCR0))]
     - Vol3A[13(SYSTEM PROGRAMMING FOR INSTRUCTION SET EXTENSIONS AND PROCESSOR EXTENDED)]
 
+  - bit: 19
+    short_name: KL
+    long_name: KEY_LOCKER_ENABLE
+    short_description: Key-Locker-Enable
+    long_description: |
+      When set, the LOADIWKEY instruction is enabled; in addition, if support for the AES Key Locker
+      instructions has been activated by system firmware, CPUID.19H:EBX.AESKLE[bit 0] is enumerated
+      as 1 and the AES Key Locker instructions are enabled. When clear, CPUID.19H:EBX.AESKLE[bit 0]
+      is enumerated as 0 and execution of any Key Locker instruction causes an invalid-opcode exception
+      (#UD).
+
   - bit: 20
     short_name: SMEP
     long_name: SMEP_ENABLE
@@ -224,3 +245,21 @@
       with a protection key. The PKRU register specifies, for each protection key, whether user-mode linear
       addresses with that protection key can be read or written. This bit also enables access to the PKRU register
       using the RDPKRU and WRPKRU instructions.
+
+  - bit: 23
+    short_name: CET
+    long_name: CONTROL_FLOW_ENFORCEMENT_ENABLE
+    short_description: Control-flow Enforcement Technology
+    long_description: |
+      Enables control-flow enforcement technology when set. This flag can be set only if CR0.WP is set,
+      and it must be clear before CR0.WP can be cleared.
+    see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+  - bit: 24
+    short_name: PKS
+    long_name: PROTECTION_KEY_FOR_SUPERVISOR_MODE_ENABLE
+    short_description: Enable protection keys for supervisor-mode pages
+    long_description: |
+      4-level paging and 5-level paging associate each supervisor-mode linear address with a protection
+      key. When set, this flag allows use of the IA32_PKRS MSR to specify, for each protection key,
+      whether supervisor-mode linear addresses with that protection key can be read or written.

--- a/yaml/Intel/ModelSpecificRegisters/ArchitecturalMsr.yml
+++ b/yaml/Intel/ModelSpecificRegisters/ArchitecturalMsr.yml
@@ -3205,13 +3205,11 @@
       short_description: Whether the guest IA32_PAT MSR is saved on VM-exit
       long_description: This control determines whether the IA32_PAT MSR is saved on VM exit.
 
-
     - bit: 19
       short_name: LOAD_HOST_PAT_MSR
       long_name: LOAD_IA32_PAT
       short_description: Whether the host IA32_PAT MSR is loaded on VM-exit
       long_description: This control determines whether the IA32_PAT MSR is loaded on VM exit.
-
 
     - bit: 20
       short_name: SAVE_GUEST_EFER_MSR
@@ -3219,13 +3217,11 @@
       short_description: Whether the guest IA32_EFER MSR is saved on VM-exit
       long_description: This control determines whether the IA32_EFER MSR is saved on VM exit.
 
-
     - bit: 21
       short_name: LOAD_HOST_EFER_MSR
       long_name: LOAD_IA32_EFER
       short_description: Whether the host IA32_EFER MSR is loaded on VM-exit
       long_description: This control determines whether the IA32_EFER MSR is loaded on VM exit.
-
 
     - bit: 22
       short_name: SAVE_VMX_PREEMPT_TIMER
@@ -3233,16 +3229,10 @@
       short_description: Whether the value of the VMX preemption timer is saved on every VM-exit
       long_description: This control determines whether the value of the VMX-preemption timer is saved on VM exit.
 
-    #
-    # Note:
-    # Bit 23 & Bit 24 is not in virtualbox's hm_vmx.h
-    #
-
     - bit: 23
       short_name: CLEAR_BNDCFGS
       long_name: CLEAR_IA32_BNDCFGS
       description: This control determines whether the IA32_BNDCFGS MSR is cleared on VM exit.
-
 
     - bit: 24
       name: CONCEAL_VMX_FROM_PT
@@ -3250,6 +3240,26 @@
         If this control is 1, Intel Processor Trace does not produce a paging information packet (PIP) on
         a VM exit or a VMCS packet on an SMM VM exit.
       see: Vol3C[35(INTEL® PROCESSOR TRACE)]
+
+    - bit: 25
+      short_name: CLEAR_RTIT_CTL
+      long_name: CLEAR_IA32_RTIT_CTL
+      description: |
+        This control determines whether the IA32_RTIT_CTL MSR is cleared on VM exit.
+      see: Vol3C[35(INTEL® PROCESSOR TRACE)]
+
+    - bit: 28
+      short_name: LOAD_HOST_CET_STATE
+      long_name: LOAD_IA32_CET_STATE
+      description: |
+        This control determines whether CET-related MSRs and SPP are loaded on VM exit.
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+    - bit: 29
+      short_name: LOAD_HOST_PKRS
+      long_name: LOAD_IA32_PKRS
+      description: |
+        This control determines whether the IA32_PKRS MSR is loaded on VM exit.
 
 - value: 0x484
   name: VMX_ENTRY_CTLS
@@ -3340,6 +3350,11 @@
     - bit: 20
       name: LOAD_CET_STATE
       description: This control determines whether CET-related MSRs and SPP are loaded on VM entry.
+
+    - bit: 22
+      short_name: LOAD_GUEST_PKRS
+      long_name: LOAD_IA32_PKRS
+      description: This control determines whether the IA32_PKRS MSR is loaded on VM entry.
 
 - value: 0x485
   name: VMX_MISC
@@ -4665,6 +4680,202 @@
   remarks: |
     If CPUID.01H:EDX.DS[21] = 1
   see: Vol3B[18.6.3.4(Debug Store (DS) Mechanism)]
+
+- value: 0x6A0
+  name: U_CET
+  description: Configure User Mode CET
+  access: R/W
+  remarks: |
+    - Bits 1:0 are defined if CPUID.(EAX=07H,ECX=0H):ECX.CET_SS[07] = 1.
+    - Bits 5:2 and bits 63:10 are defined if CPUID.(EAX=07H,ECX=0H):EDX.CET_IBT[20] = 1.
+  fields:
+  - name_with_suffix: REGISTER
+    type: bitfield
+    size: 64
+    fields:
+    - bit: 0
+      name: SH_STK_EN
+      description: When set to 1, enable shadow stacks at CPL3.
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+    - bit: 1
+      name: WR_SHSTK_EN
+      description: When set to 1, enables the WRSSD/WRSSQ instructions.
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+    - bit: 2
+      name: ENDBR_EN
+      description: When set to 1, enables indirect branch tracking
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+    - bit: 3
+      name: LEG_IW_EN
+      description: Enable legacy compatibility treatment for indirect branch tracking.
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+    - bit: 4
+      name: NO_TRACK_EN
+      description: When set to 1, enables use of no-track prefix for indirect branch tracking.
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+    - bit: 5
+      name: SUPPRESS_DIS
+      description: When set to 1, disables suppression of CET indirect branch tracking on legacy compatibility.
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+    - bit: 10
+      name: SUPPRESS
+      description: |
+        When set to 1, indirect branch tracking is suppressed. This bit can be written to 1 only if
+        TRACKER is written as IDLE.
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+    - bit: 11
+      name: TRACKER
+      description: |
+        Value of the indirect branch tracking state machine. Values: IDLE (0), WAIT_FOR_ENDBRANCH(1).
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+    - bit: 12-63
+      name: EB_LEG_BITMAP_BASE
+      description: |
+        Linear address bits 63:12 of a legacy code page bitmap used for legacy compatibility when
+        indirect branch tracking is enabled. If the processor does not support Intel 64 architecture,
+        these fields have only 32 bits; bits 63:32 of the MSRs are reserved. On processors that support
+        Intel 64 architecture this value cannot represent a non-canonical address. In protected mode,
+        only 31:0 are loaded. The linear address written must be aligned to 8 bytes and bits 2:0 must
+        be 0 (hardware requires bits 1:0 to be 0).
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+- value: 0x6A2
+  name: S_CET
+  description: Configure Supervisor Mode CET
+  access: R/W
+  remarks: |
+    - Bits 1:0 are defined if CPUID.(EAX=07H,ECX=0H):ECX.CET_SS[07] = 1.
+    - Bits 5:2 and bits 63:10 are defined if CPUID.(EAX=07H,ECX=0H):EDX.CET_IBT[20] = 1.
+  fields:
+  - name_with_suffix: REGISTER
+    type: bitfield
+    size: 64
+    fields:
+    - bit: 0
+      name: SH_STK_EN
+      description: When set to 1, enable shadow stacks at CPL3.
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+    - bit: 1
+      name: WR_SHSTK_EN
+      description: When set to 1, enables the WRSSD/WRSSQ instructions.
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+    - bit: 2
+      name: ENDBR_EN
+      description: When set to 1, enables indirect branch tracking
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+    - bit: 3
+      name: LEG_IW_EN
+      description: Enable legacy compatibility treatment for indirect branch tracking.
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+    - bit: 4
+      name: NO_TRACK_EN
+      description: When set to 1, enables use of no-track prefix for indirect branch tracking.
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+    - bit: 5
+      name: SUPPRESS_DIS
+      description: When set to 1, disables suppression of CET indirect branch tracking on legacy compatibility.
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+    - bit: 10
+      name: SUPPRESS
+      description: |
+        When set to 1, indirect branch tracking is suppressed. This bit can be written to 1 only if
+        TRACKER is written as IDLE.
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+    - bit: 11
+      name: TRACKER
+      description: |
+        Value of the indirect branch tracking state machine. Values: IDLE (0), WAIT_FOR_ENDBRANCH(1).
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+    - bit: 12-63
+      name: EB_LEG_BITMAP_BASE
+      description: |
+        Linear address bits 63:12 of a legacy code page bitmap used for legacy compatibility when
+        indirect branch tracking is enabled. If the processor does not support Intel 64 architecture,
+        these fields have only 32 bits; bits 63:32 of the MSRs are reserved. On processors that support
+        Intel 64 architecture this value cannot represent a non-canonical address. In protected mode,
+        only 31:0 are loaded. The linear address written must be aligned to 8 bytes and bits 2:0 must
+        be 0 (hardware requires bits 1:0 to be 0).
+      see: Vol1[18(CONTROL-FLOW ENFORCEMENT TECHNOLOGY (CET))]
+
+- value: 0x6A4
+  name: PL0_SSP
+  description: |
+    Linear address to be loaded into SSP on transition to privilege level 0.
+
+    If the processor does not support Intel 64 architecture, these fields have only 32 bits; bits
+    63:32 of the MSRs are reserved. On processors that support Intel 64 architecture this value cannot
+    represent a non-canonical address. In protected mode, only 31:0 are loaded. The linear address
+    written must be aligned to 8 bytes and bits 2:0 must be 0 (hardware requires bits 1:0 to be 0).
+  access: R/W
+  remarks: |
+    If CPUID.(EAX=07H, ECX=0H):ECX.CET_SS[07] = 1
+
+- value: 0x6A5
+  name: PL1_SSP
+  description: |
+    Linear address to be loaded into SSP on transition to privilege level 1.
+
+    If the processor does not support Intel 64 architecture, these fields have only 32 bits; bits
+    63:32 of the MSRs are reserved. On processors that support Intel 64 architecture this value cannot
+    represent a non-canonical address. In protected mode, only 31:0 are loaded. The linear address
+    written must be aligned to 8 bytes and bits 2:0 must be 0 (hardware requires bits 1:0 to be 0).
+  access: R/W
+  remarks: |
+    If CPUID.(EAX=07H, ECX=0H):ECX.CET_SS[07] = 1
+
+- value: 0x6A6
+  name: PL2_SSP
+  description: |
+    Linear address to be loaded into SSP on transition to privilege level 2.
+
+    If the processor does not support Intel 64 architecture, these fields have only 32 bits; bits
+    63:32 of the MSRs are reserved. On processors that support Intel 64 architecture this value cannot
+    represent a non-canonical address. In protected mode, only 31:0 are loaded. The linear address
+    written must be aligned to 8 bytes and bits 2:0 must be 0 (hardware requires bits 1:0 to be 0).
+  access: R/W
+  remarks: |
+    If CPUID.(EAX=07H, ECX=0H):ECX.CET_SS[07] = 1
+
+- value: 0x6A7
+  name: PL3_SSP
+  description: |
+    Linear address to be loaded into SSP on transition to privilege level 3.
+
+    If the processor does not support Intel 64 architecture, these fields have only 32 bits; bits
+    63:32 of the MSRs are reserved. On processors that support Intel 64 architecture this value cannot
+    represent a non-canonical address. In protected mode, only 31:0 are loaded. The linear address
+    written must be aligned to 8 bytes and bits 2:0 must be 0 (hardware requires bits 1:0 to be 0).
+  access: R/W
+  remarks: |
+    If CPUID.(EAX=07H, ECX=0H):ECX.CET_SS[07] = 1
+
+- value: 0x6A8
+  name: INTERRUPT_SSP_TABLE_ADDR
+  description: |
+    Linear address of a table of seven shadow stack pointers that are selected in IA-32e mode using
+    the IST index (when not 0) from the interrupt gate descriptor.
+
+    This MSR is not present on processors that do not support Intel 64 architecture. This field cannot
+    represent a non-canonical address.
+  access: R/W
+  remarks: |
+    If CPUID.(EAX=07H, ECX=0H):ECX.CET_SS[07] = 1
 
 - value: 0x6E0
   name: TSC_DEADLINE

--- a/yaml/Intel/VMX/EPT.yml
+++ b/yaml/Intel/VMX/EPT.yml
@@ -54,7 +54,7 @@
       description: Bits N–1:12 of the physical address of the 4-KByte aligned EPT PML4 table.
 
   - short_name: EPML4E
-    long_name: EPT_PML4
+    long_name: EPT_PML4E
     short_description: Format of an EPT PML4 Entry (PML4E) that References an EPT Page-Directory-Pointer Table
     long_description: |
       A 4-KByte naturally aligned EPT PML4 table is located at the physical address specified in bits 51:12 of the
@@ -117,8 +117,8 @@
       long_name: PAGE_FRAME_NUMBER
       description: Physical address of 4-KByte aligned EPT page-directory-pointer table referenced by this entry.
 
-  - short_name: EPT_PDPTE_1GB
-    long_name: EPDPTE_1GB
+  - short_name: EPDPTE_1GB
+    long_name: EPT_PDPTE_1GB
     description: Format of an EPT Page-Directory-Pointer-Table Entry (PDPTE) that Maps a 1-GByte Page.
     type: bitfield
     size: 64
@@ -199,8 +199,8 @@
         control is 0, this bit is ignored.
       see: Vol3C[25.5.6.1(Convertible EPT Violations)]
 
-  - short_name: EPT_PDPTE
-    long_name: EPDPTE
+  - short_name: EPDPTE
+    long_name: EPT_PDPTE
     description: Format of an EPT Page-Directory-Pointer-Table Entry (PDPTE) that References an EPT Page Directory.
     type: bitfield
     size: 64
@@ -246,8 +246,8 @@
       long_name: PAGE_FRAME_NUMBER
       description: Physical address of 4-KByte aligned EPT page-directory-pointer table referenced by this entry.
 
-  - short_name: EPT_PDE_2MB
-    long_name: EPDE_2MB
+  - short_name: EPDE_2MB
+    long_name: EPT_PDE_2MB
     description: Format of an EPT Page-Directory Entry (PDE) that Maps a 2-MByte Page.
     type: bitfield
     size: 64
@@ -328,8 +328,8 @@
         control is 0, this bit is ignored.
       see: Vol3C[25.5.6.1(Convertible EPT Violations)]
 
-  - short_name: EPT_PDE
-    long_name: EPDE
+  - short_name: EPDE
+    long_name: EPT_PDE
     description: Format of an EPT Page-Directory Entry (PDE) that References an EPT Page Table.
     type: bitfield
     size: 64
@@ -375,8 +375,8 @@
       long_name: PAGE_FRAME_NUMBER
       description: Physical address of 4-KByte aligned EPT page table referenced by this entry.
 
-  - short_name: EPT_PTE
-    long_name: EPTE
+  - short_name: EPTE
+    long_name: EPT_PTE
     description: Format of an EPT Page-Table Entry that Maps a 4-KByte Page.
     type: bitfield
     size: 64

--- a/yaml/Intel/VMX/VMCS.yml
+++ b/yaml/Intel/VMX/VMCS.yml
@@ -437,10 +437,25 @@
           long_name: ENCLS_EXITING_BITMAP
           description: ENCLS-exiting bitmap.
 
+        - value: 0x2030
+          short_name: SPP_TABLE_POINTER
+          long_name: SUB_PAGE_PERMISSION_TABLE_POINTER
+          description: Sub-page-permission-table pointer.
+
         - value: 0x2032
           short_name: TSC_MULTIPLIER
           long_name: TSC_MULTIPLIER
           description: TSC multiplier.
+
+        - value: 0x2034
+          short_name: PROC_EXEC3
+          long_name: TERTIARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS
+          description: Tertiary processor-based VM-execution controls.
+
+        - value: 0x2036
+          short_name: ENCLV_EXITING_BITMAP
+          long_name: ENCLV_EXITING_BITMAP
+          description: ENCLV-exiting bitmap.
 
       - name: 64_BIT_READ_ONLY_DATA_FIELDS
         description: 64-Bit Read-Only Data Field.
@@ -512,6 +527,11 @@
           long_name: RTIT_CTL
           description: Guest IA32_RTIT_CTL.
 
+        - value: 0x2818
+          short_name: PKRS
+          long_name: PKRS
+          description: Guest IA32_PKRS
+
       - name: 64_BIT_HOST_STATE_FIELDS
         description: 64-Bit Host-State Fields.
         children_name_with_prefix: HOST
@@ -531,6 +551,11 @@
           short_name: PERF_GLOBAL_CTRL
           long_name: PERF_GLOBAL_CTRL
           description: Host IA32_PERF_GLOBAL_CTRL.
+
+        - value: 0x2C06
+          short_name: PKRS
+          long_name: PKRS
+          description: Host IA32_PKRS
 
   - name: 32_BIT
     description: 32-Bit Fields.


### PR DESCRIPTION
This PR consists of two major parts:

- 6d630e8: Corrects inconsistently named EPML4, EPDPTE(_1GB), EPDE(_2MB) and EPTE. There is a couple of issues. 
  1) `short_name` of them are inconsistent in that EPT PML4 is named in the format of `E` + level, eg, `EPML4E`, while the others are `EPT_` + level, eg `EPT_PDPTE`. Since it is a short name, all of them should be named in the format of `E` + level, eg, `EPDPTE`, instead. 
  2) `long_name` of EPT PML4 is inconsistent in that it does not have the `E` suffix, ie, `EPT_PML4`, while all others have, eg, `EPML4E`. All of those structures are for entries and not for tables, having the `E` suffix is appropriate. 

- The rest of commits: Those are opportunistic updates based on the April 2021 edition. The structures updated in those commits completely reflect the definitions in the manual now. For obvious reasons, those commits do not attempt to reflect other updates in the manual.  

As always, those are breaking changes. 