### PR TITLE
Add new VMX-related definitions

### DIFF
--- a/out/ia32.h
+++ b/out/ia32.h
@@ -11390,7 +11390,15 @@ typedef union
 #define IA32_VMX_EXIT_CTLS_CLEAR_IA32_LBR_CTL_FLAG                   0x4000000
 #define IA32_VMX_EXIT_CTLS_CLEAR_IA32_LBR_CTL_MASK                   0x01
 #define IA32_VMX_EXIT_CTLS_CLEAR_IA32_LBR_CTL(_)                     (((_) >> 26) & 0x01)
-    UINT64 Reserved6                                               : 1;
+
+    /**
+     * [Bit 27] This control determines whether UINV is cleared on VM exit.
+     */
+    UINT64 ClearUinv                                               : 1;
+#define IA32_VMX_EXIT_CTLS_CLEAR_UINV_BIT                            27
+#define IA32_VMX_EXIT_CTLS_CLEAR_UINV_FLAG                           0x8000000
+#define IA32_VMX_EXIT_CTLS_CLEAR_UINV_MASK                           0x01
+#define IA32_VMX_EXIT_CTLS_CLEAR_UINV(_)                             (((_) >> 27) & 0x01)
 
     /**
      * [Bit 28] This control determines whether CET-related MSRs and SPP are loaded on VM exit.
@@ -11411,7 +11419,15 @@ typedef union
 #define IA32_VMX_EXIT_CTLS_LOAD_IA32_PKRS_FLAG                       0x20000000
 #define IA32_VMX_EXIT_CTLS_LOAD_IA32_PKRS_MASK                       0x01
 #define IA32_VMX_EXIT_CTLS_LOAD_IA32_PKRS(_)                         (((_) >> 29) & 0x01)
-    UINT64 Reserved7                                               : 1;
+
+    /**
+     * [Bit 30] This control determines whether the IA32_PERF_GLOBAL_CTL MSR is saved on VM exit.
+     */
+    UINT64 SaveIa32PerfGlobalCtl                                   : 1;
+#define IA32_VMX_EXIT_CTLS_SAVE_IA32_PERF_GLOBAL_CTL_BIT             30
+#define IA32_VMX_EXIT_CTLS_SAVE_IA32_PERF_GLOBAL_CTL_FLAG            0x40000000
+#define IA32_VMX_EXIT_CTLS_SAVE_IA32_PERF_GLOBAL_CTL_MASK            0x01
+#define IA32_VMX_EXIT_CTLS_SAVE_IA32_PERF_GLOBAL_CTL(_)              (((_) >> 30) & 0x01)
 
     /**
      * [Bit 31] This control determines whether the secondary VM-exit controls are used. If this control is 0, the logical
@@ -11422,7 +11438,7 @@ typedef union
 #define IA32_VMX_EXIT_CTLS_ACTIVATE_SECONDARY_CONTROLS_FLAG          0x80000000
 #define IA32_VMX_EXIT_CTLS_ACTIVATE_SECONDARY_CONTROLS_MASK          0x01
 #define IA32_VMX_EXIT_CTLS_ACTIVATE_SECONDARY_CONTROLS(_)            (((_) >> 31) & 0x01)
-    UINT64 Reserved8                                               : 32;
+    UINT64 Reserved6                                               : 32;
   };
 
   UINT64 AsUInt;
@@ -11559,7 +11575,15 @@ typedef union
 #define IA32_VMX_ENTRY_CTLS_LOAD_IA32_RTIT_CTL_FLAG                  0x40000
 #define IA32_VMX_ENTRY_CTLS_LOAD_IA32_RTIT_CTL_MASK                  0x01
 #define IA32_VMX_ENTRY_CTLS_LOAD_IA32_RTIT_CTL(_)                    (((_) >> 18) & 0x01)
-    UINT64 Reserved4                                               : 1;
+
+    /**
+     * [Bit 19] This control determines whether UINV is loaded on VM entry.
+     */
+    UINT64 LoadUinv                                                : 1;
+#define IA32_VMX_ENTRY_CTLS_LOAD_UINV_BIT                            19
+#define IA32_VMX_ENTRY_CTLS_LOAD_UINV_FLAG                           0x80000
+#define IA32_VMX_ENTRY_CTLS_LOAD_UINV_MASK                           0x01
+#define IA32_VMX_ENTRY_CTLS_LOAD_UINV(_)                             (((_) >> 19) & 0x01)
 
     /**
      * [Bit 20] This control determines whether CET-related MSRs and SPP are loaded on VM entry.
@@ -11587,7 +11611,7 @@ typedef union
 #define IA32_VMX_ENTRY_CTLS_LOAD_IA32_PKRS_FLAG                      0x400000
 #define IA32_VMX_ENTRY_CTLS_LOAD_IA32_PKRS_MASK                      0x01
 #define IA32_VMX_ENTRY_CTLS_LOAD_IA32_PKRS(_)                        (((_) >> 22) & 0x01)
-    UINT64 Reserved5                                               : 41;
+    UINT64 Reserved4                                               : 41;
   };
 
   UINT64 AsUInt;
@@ -12126,7 +12150,17 @@ typedef union
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_XSAVES_FLAG                  0x100000
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_XSAVES_MASK                  0x01
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_XSAVES(_)                    (((_) >> 20) & 0x01)
-    UINT64 Reserved1                                               : 1;
+
+    /**
+     * [Bit 21] If this control is 1, PASID translation is performed for executions of ENQCMD and ENQCMDS.
+     *
+     * @see Vol3C[27.5.8(PASID Translation)]
+     */
+    UINT64 EnablePasidTranslation                                  : 1;
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PASID_TRANSLATION_BIT        21
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PASID_TRANSLATION_FLAG       0x200000
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PASID_TRANSLATION_MASK       0x01
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PASID_TRANSLATION(_)         (((_) >> 21) & 0x01)
 
     /**
      * [Bit 22] If this control is 1, EPT execute permissions are based on whether the linear address being accessed is
@@ -12188,7 +12222,17 @@ typedef union
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_USER_WAIT_PAUSE_FLAG         0x4000000
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_USER_WAIT_PAUSE_MASK         0x01
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_USER_WAIT_PAUSE(_)           (((_) >> 26) & 0x01)
-    UINT64 Reserved2                                               : 1;
+
+    /**
+     * @brief Enables the PCONFIG instruction
+     *
+     * [Bit 27] If this control is 0, any execution of PCONFIG causes a \#UD.
+     */
+    UINT64 EnablePconfig                                           : 1;
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PCONFIG_BIT                  27
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PCONFIG_FLAG                 0x8000000
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PCONFIG_MASK                 0x01
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PCONFIG(_)                   (((_) >> 27) & 0x01)
 
     /**
      * @brief Enables ENCLV VM-exits
@@ -12204,7 +12248,36 @@ typedef union
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_ENCLV_EXITING_FLAG           0x10000000
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_ENCLV_EXITING_MASK           0x01
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_ENCLV_EXITING(_)             (((_) >> 28) & 0x01)
-    UINT64 Reserved3                                               : 35;
+    UINT64 Reserved1                                               : 1;
+
+    /**
+     * @brief Enables VM-exits on bus lock assertions
+     *
+     * [Bit 30] This control determines whether assertion of a bus lock causes a VM exit.
+     *
+     * @see Vol3C[27.2(OTHER CAUSES OF VM EXIT)]
+     */
+    UINT64 EnableVmmBusLockDetection                               : 1;
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_VMM_BUS_LOCK_DETECTION_BIT   30
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_VMM_BUS_LOCK_DETECTION_FLAG  0x40000000
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_VMM_BUS_LOCK_DETECTION_MASK  0x01
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_VMM_BUS_LOCK_DETECTION(_)    (((_) >> 30) & 0x01)
+
+    /**
+     * @brief Enables VM-exits on instructions that block for a certain amount of time
+     *
+     * [Bit 31] If this control is 1, a VM exit occurs if certain operations prevent the processor from reaching an instruction
+     * boundary within a specified amount of time.
+     *
+     * @see Vol3C[26.6.25(Instruction-Timeout Contro)]
+     * @see Vol3C[27.2(OTHER CAUSES OF VM EXIT)]
+     */
+    UINT64 EnableInstructionTimeoutExit                            : 1;
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_INSTRUCTION_TIMEOUT_EXIT_BIT 31
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_INSTRUCTION_TIMEOUT_EXIT_FLAG 0x80000000
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_INSTRUCTION_TIMEOUT_EXIT_MASK 0x01
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_INSTRUCTION_TIMEOUT_EXIT(_)  (((_) >> 31) & 0x01)
+    UINT64 Reserved2                                               : 32;
   };
 
   UINT64 AsUInt;
@@ -12571,7 +12644,47 @@ typedef union
 #define IA32_VMX_PROCBASED_CTLS3_GUEST_PAGING_FLAG                   0x08
 #define IA32_VMX_PROCBASED_CTLS3_GUEST_PAGING_MASK                   0x01
 #define IA32_VMX_PROCBASED_CTLS3_GUEST_PAGING(_)                     (((_) >> 3) & 0x01)
-    UINT64 Reserved1                                               : 60;
+
+    /**
+     * @brief Enables virtualization of IPIs
+     *
+     * [Bit 4] If this control is 1, virtualization of interprocessor interrupts (IPIs) is enabled.
+     *
+     * @see Vol3C[31.1.6(IPI Virtualization)]
+     */
+    UINT64 EnableIpiVirtualization                                 : 1;
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_IPI_VIRTUALIZATION_BIT       4
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_IPI_VIRTUALIZATION_FLAG      0x10
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_IPI_VIRTUALIZATION_MASK      0x01
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_IPI_VIRTUALIZATION(_)        (((_) >> 4) & 0x01)
+    UINT64 Reserved1                                               : 1;
+
+    /**
+     * @brief Enables RDMSRLIST/WRMSRLIST instructions
+     *
+     * [Bit 6] If this control is 0, any execution of RDMSRLIST or WRMSRLIST causes a \#UD.
+     */
+    UINT64 EnableRdmsrlistWrmsrlist                                : 1;
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_RDMSRLIST_WRMSRLIST_BIT      6
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_RDMSRLIST_WRMSRLIST_FLAG     0x40
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_RDMSRLIST_WRMSRLIST_MASK     0x01
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_RDMSRLIST_WRMSRLIST(_)       (((_) >> 6) & 0x01)
+
+    /**
+     * @brief Changes access to the IA32_SPEC_CTRL MSR
+     *
+     * [Bit 7] If this control is 1, the operation of the RDMSR and WRMSR instructions is changed when accessing the
+     * IA32_SPEC_CTRL MSR.
+     *
+     * @see Vol3C[26.6.26(Fields Controlling Virtualization of the IA32_SPEC_CTRL MSR)]
+     * @see Vol3C[27.3(CHANGES TO INSTRUCTION BEHAVIOR IN VMX NON-ROOT OPERATION)]
+     */
+    UINT64 VirtualizeIa32SpecCtrl                                  : 1;
+#define IA32_VMX_PROCBASED_CTLS3_VIRTUALIZE_IA32_SPEC_CTRL_BIT       7
+#define IA32_VMX_PROCBASED_CTLS3_VIRTUALIZE_IA32_SPEC_CTRL_FLAG      0x80
+#define IA32_VMX_PROCBASED_CTLS3_VIRTUALIZE_IA32_SPEC_CTRL_MASK      0x01
+#define IA32_VMX_PROCBASED_CTLS3_VIRTUALIZE_IA32_SPEC_CTRL(_)        (((_) >> 7) & 0x01)
+    UINT64 Reserved2                                               : 56;
   };
 
   UINT64 AsUInt;
@@ -12590,11 +12703,22 @@ typedef union
 {
   struct
   {
-    UINT64 Reserved                                                : 64;
-#define IA32_VMX_EXIT_CTLS2_RESERVED_BIT                             0
-#define IA32_VMX_EXIT_CTLS2_RESERVED_FLAG                            0xFFFFFFFFFFFFFFFF
-#define IA32_VMX_EXIT_CTLS2_RESERVED_MASK                            0xFFFFFFFFFFFFFFFF
-#define IA32_VMX_EXIT_CTLS2_RESERVED(_)                              (((_) >> 0) & 0xFFFFFFFFFFFFFFFF)
+    UINT64 Reserved1                                               : 3;
+
+    /**
+     * @brief Enables indication of when a VM-exit causes a shadow stack to become prematurely busy
+     *
+     * [Bit 3] If this control is 1, VM exits that cause a shadow stack to become prematurely busy indicate this fact and save
+     * additional information into the VMCS.
+     *
+     * @see Vol1[18.2.3(Supervisor Shadow Stack Token)]
+     */
+    UINT64 EnablePrematurelyBusyShadowStackIndication              : 1;
+#define IA32_VMX_EXIT_CTLS2_ENABLE_PREMATURELY_BUSY_SHADOW_STACK_INDICATION_BIT 3
+#define IA32_VMX_EXIT_CTLS2_ENABLE_PREMATURELY_BUSY_SHADOW_STACK_INDICATION_FLAG 0x08
+#define IA32_VMX_EXIT_CTLS2_ENABLE_PREMATURELY_BUSY_SHADOW_STACK_INDICATION_MASK 0x01
+#define IA32_VMX_EXIT_CTLS2_ENABLE_PREMATURELY_BUSY_SHADOW_STACK_INDICATION(_) (((_) >> 3) & 0x01)
+    UINT64 Reserved2                                               : 60;
   };
 
   UINT64 AsUInt;
@@ -18032,6 +18156,128 @@ typedef struct
  * the following three values: EDX:EAX, the IA32_XSS MSR, and the XSS-exiting bitmap.
  */
 #define VMX_EXIT_REASON_EXECUTE_XRSTORS                              0x00000040
+
+/**
+ * @brief PCONFIG
+ *
+ * Guest software attempted to execute PCONFIG, "enable PCONFIG" VM-execution control was 1, and either (1) EAX < 63 and
+ * the corresponding bit in the PCONFIG-exiting bitmap is 1; or (2) EAX ? 63 and bit 63 in the PCONFIG-exiting bitmap is 1.
+ */
+#define VMX_EXIT_REASON_EXECUTE_PCONFIG                              0x00000041
+
+/**
+ * @brief SPP-related event
+ *
+ * SPP-related event. The processor attempted to determine an access's sub-page write permission and encountered an SPP
+ * miss or an SPP misconfiguration.
+ *
+ * @see Vol3C[30.3.4.2(Determining an Access's Sub-Page Write Permission)]
+ */
+#define VMX_EXIT_REASON_SPP_RELATED_EVENT                            0x00000042
+
+/**
+ * @brief UMWAIT
+ *
+ * Guest software attempted to execute UMWAIT and the "enable user wait and pause" and "RDTSC exiting" VM-execution
+ * controls were both 1.
+ */
+#define VMX_EXIT_REASON_EXECUTE_UMWAIT                               0x00000043
+
+/**
+ * @brief TPAUSE
+ *
+ * Guest software attempted to execute TPAUSE and the "enable user wait and pause" and "RDTSC exiting" VM-execution
+ * controls were both 1.
+ */
+#define VMX_EXIT_REASON_EXECUTE_TPAUSE                               0x00000044
+
+/**
+ * @brief LOADIWKEY
+ *
+ * Guest software attempted to execute LOADIWKEY and the "LOADIWKEY exiting" VM-execution control was 1.
+ */
+#define VMX_EXIT_REASON_EXECUTE_LOADIWKEY                            0x00000045
+
+/**
+ * @brief ENCLV
+ *
+ * Guest software attempted to execute ENCLV, the "enable ENCLV exiting" VM-execution control was 1, and either (1) EAX <
+ * 63 and the corresponding bit in the ENCLV-exiting bitmap is 1; or (2) EAX ? 63 and bit 63 in the ENCLV-exiting bitmap is
+ * 1.
+ */
+#define VMX_EXIT_REASON_EXECUTE_ENCLV                                0x00000046
+
+/**
+ * @brief ENQCMD PASID translation failure
+ *
+ * A VM exit occurred during PASID translation because the present bit was clear in a PASID-directory entry, the valid bit
+ * was clear in a PASID-table entry, or one of the entries set a reserved bit.
+ */
+#define VMX_EXIT_REASON_EXECUTE_ENQCMD                               0x00000048
+
+/**
+ * @brief ENQCMDS PASID translation failure
+ *
+ * A VM exit occurred during PASID translation because the present bit was clear in a PASID-directory entry, the valid bit
+ * was clear in a PASID-table entry, or one of the entries set a reserved bit.
+ */
+#define VMX_EXIT_REASON_EXECUTE_ENQCMDS                              0x00000049
+
+/**
+ * @brief Bus lock
+ *
+ * The processor asserted a bus lock while the "bus-lock detection" VM-execution control was 1. (Such VM exits will also
+ * set bit 26 of the exit-reason field.)
+ */
+#define VMX_EXIT_REASON_BUS_LOCK_ASSERTION                           0x0000004A
+
+/**
+ * @brief Instruction timeout
+ *
+ * The "instruction timeout" VM-execution control was 1 and certain operations prevented the processor from reaching an
+ * instruction boundary within the amount of time specified by the instruction-timeout control.
+ */
+#define VMX_EXIT_REASON_INSTRUCTION_TIMEOUT                          0x0000004B
+
+/**
+ * @brief SEAMCALL
+ *
+ * Guest software attempted to execute SEAMCALL.
+ */
+#define VMX_EXIT_REASON_EXECUTE_SEAMCALL                             0x0000004C
+
+/**
+ * @brief TDCALL
+ *
+ * Guest software attempted to execute TDCALL.
+ */
+#define VMX_EXIT_REASON_EXECUTE_TDCALL                               0x0000004D
+
+/**
+ * @brief RDMSRLIST
+ *
+ * Guest software attempted to execute RDMSRLIST and either the "use MSR bitmaps" VM-execution control was 0 or any of the
+ * following holds for the index an MSR being accessed:
+ * * The index is neither in the range 00000000H - 00001FFFH nor in the range C0000000H - C0001FFFH.
+ * * The index is in the range 00000000H - 00001FFFH and the nth bit in read bitmap for low MSRs is 1, where n is the
+ * index.
+ * * The index is in the range C0000000H - C0001FFFH and the nth bit in read bitmap for high MSRs is 1, where n is the
+ * logical AND of the index and the value 00001FFFH.
+ */
+#define VMX_EXIT_REASON_EXECUTE_RDMSRLIST                            0x0000004E
+
+/**
+ * @brief WRMSRLIST
+ *
+ * Guest software attempted to execute WRMSRLIST and either the "use MSR bitmaps" VM-execution control was 0 or any of the
+ * following holds for the index an MSR being accessed:
+ * * The index is neither in the range 00000000H - 00001FFFH nor in the range C0000000H - C0001FFFH.
+ * * The index is in the range 00000000H - 00001FFFH and the nth bit in write bitmap for low MSRs is 1, where n is the
+ * index.
+ * * The index is in the range C0000000H - C0001FFFH and the nth bit in write bitmap for high MSRs is 1, where n is the
+ * logical AND of the index and the value 00001FFFH.
+ */
+#define VMX_EXIT_REASON_EXECUTE_WRMSRLIST                            0x0000004F
 /**
  * @}
  */
@@ -21191,6 +21437,14 @@ typedef union
  * @remarks This field exists only on processors that support the 1-setting of the "enable HLAT" VM-execution control.
  */
 #define VMCS_CTRL_HLAT_PREFIX_SIZE                                   0x00000006
+
+/**
+ * Last PID-pointer index.
+ *
+ * @remarks This field exists only on processors that support the 1-setting of the "IPI virtualization" VM-execution
+ *          control
+ */
+#define VMCS_CTRL_LAST_PID_POINTER_INDEX                             0x00000008
 /**
  * @}
  */
@@ -21256,6 +21510,14 @@ typedef union
  * @remarks This field exists only on processors that support the 1-setting of the "enable PML" VM-execution control.
  */
 #define VMCS_GUEST_PML_INDEX                                         0x00000812
+
+/**
+ * UINV.
+ *
+ * @remarks This field exists only on processors that support the 1-setting of either the "clear UINV" VM-exit control or
+ *          the "load UINV" VM-entry control.
+ */
+#define VMCS_GUEST_UINV                                              0x00000814
 /**
  * @}
  */
@@ -21466,14 +21728,49 @@ typedef union
 #define VMCS_CTRL_ENCLV_EXITING_BITMAP                               0x00002036
 
 /**
+ * Low PASID directory address.
+ */
+#define VMCS_CTRL_LOW_PASID_DIRECTORY_ADDRESS                        0x00002038
+
+/**
+ * High PASID directory address.
+ */
+#define VMCS_CTRL_HIGH_PASID_DIRECTORY_ADDRESS                       0x0000203A
+
+/**
+ * Shared EPT pointer.
+ */
+#define VMCS_CTRL_SHARED_EPT_POINTER                                 0x0000203C
+
+/**
+ * PCONFIG-exiting bitmap.
+ */
+#define VMCS_CTRL_PCONFIG_EXITING_BITMAP                             0x0000203E
+
+/**
  * Hypervisor-managed linear-address translation pointer.
  */
 #define VMCS_CTRL_HLAT_POINTER                                       0x00002040
 
 /**
+ * PID-pointer table address.
+ */
+#define VMCS_CTRL_PID_POINTER_TABLE_ADDRESS                          0x00002042
+
+/**
  * Secondary VM-exit controls.
  */
 #define VMCS_CTRL_SECONDARY_VMEXIT_CONTROLS                          0x00002044
+
+/**
+ * IA32_SPEC_CTRL mask.
+ */
+#define VMCS_CTRL_IA32_SPEC_CTRL_MASK                                0x0000204A
+
+/**
+ * IA32_SPEC_CTRL shadow.
+ */
+#define VMCS_CTRL_IA32_SPEC_CTRL_SHADOW                              0x0000204C
 /**
  * @}
  */
@@ -22114,17 +22411,17 @@ typedef union
 /**
  * Guest IA32_S_CET.
  */
-#define VMCS_GUEST_S_CET                                             0x00006C28
+#define VMCS_GUEST_S_CET                                             0x00006828
 
 /**
  * Guest SSP.
  */
-#define VMCS_GUEST_SSP                                               0x00006C2A
+#define VMCS_GUEST_SSP                                               0x0000682A
 
 /**
  * Guest IA32_INTERRUPT_SSP_TABLE_ADDR.
  */
-#define VMCS_GUEST_INTERRUPT_SSP_TABLE_ADDR                          0x00006C2C
+#define VMCS_GUEST_INTERRUPT_SSP_TABLE_ADDR                          0x0000682C
 /**
  * @}
  */

--- a/out/ia32.hpp
+++ b/out/ia32.hpp
@@ -11390,7 +11390,15 @@ typedef union
 #define IA32_VMX_EXIT_CTLS_CLEAR_IA32_LBR_CTL_FLAG                   0x4000000
 #define IA32_VMX_EXIT_CTLS_CLEAR_IA32_LBR_CTL_MASK                   0x01
 #define IA32_VMX_EXIT_CTLS_CLEAR_IA32_LBR_CTL(_)                     (((_) >> 26) & 0x01)
-    uint64_t reserved6                                               : 1;
+
+    /**
+     * [Bit 27] This control determines whether UINV is cleared on VM exit.
+     */
+    uint64_t clear_uinv                                              : 1;
+#define IA32_VMX_EXIT_CTLS_CLEAR_UINV_BIT                            27
+#define IA32_VMX_EXIT_CTLS_CLEAR_UINV_FLAG                           0x8000000
+#define IA32_VMX_EXIT_CTLS_CLEAR_UINV_MASK                           0x01
+#define IA32_VMX_EXIT_CTLS_CLEAR_UINV(_)                             (((_) >> 27) & 0x01)
 
     /**
      * [Bit 28] This control determines whether CET-related MSRs and SPP are loaded on VM exit.
@@ -11411,7 +11419,15 @@ typedef union
 #define IA32_VMX_EXIT_CTLS_LOAD_IA32_PKRS_FLAG                       0x20000000
 #define IA32_VMX_EXIT_CTLS_LOAD_IA32_PKRS_MASK                       0x01
 #define IA32_VMX_EXIT_CTLS_LOAD_IA32_PKRS(_)                         (((_) >> 29) & 0x01)
-    uint64_t reserved7                                               : 1;
+
+    /**
+     * [Bit 30] This control determines whether the IA32_PERF_GLOBAL_CTL MSR is saved on VM exit.
+     */
+    uint64_t save_ia32_perf_global_ctl                               : 1;
+#define IA32_VMX_EXIT_CTLS_SAVE_IA32_PERF_GLOBAL_CTL_BIT             30
+#define IA32_VMX_EXIT_CTLS_SAVE_IA32_PERF_GLOBAL_CTL_FLAG            0x40000000
+#define IA32_VMX_EXIT_CTLS_SAVE_IA32_PERF_GLOBAL_CTL_MASK            0x01
+#define IA32_VMX_EXIT_CTLS_SAVE_IA32_PERF_GLOBAL_CTL(_)              (((_) >> 30) & 0x01)
 
     /**
      * [Bit 31] This control determines whether the secondary VM-exit controls are used. If this control is 0, the logical
@@ -11422,7 +11438,7 @@ typedef union
 #define IA32_VMX_EXIT_CTLS_ACTIVATE_SECONDARY_CONTROLS_FLAG          0x80000000
 #define IA32_VMX_EXIT_CTLS_ACTIVATE_SECONDARY_CONTROLS_MASK          0x01
 #define IA32_VMX_EXIT_CTLS_ACTIVATE_SECONDARY_CONTROLS(_)            (((_) >> 31) & 0x01)
-    uint64_t reserved8                                               : 32;
+    uint64_t reserved6                                               : 32;
   };
 
   uint64_t flags;
@@ -11559,7 +11575,15 @@ typedef union
 #define IA32_VMX_ENTRY_CTLS_LOAD_IA32_RTIT_CTL_FLAG                  0x40000
 #define IA32_VMX_ENTRY_CTLS_LOAD_IA32_RTIT_CTL_MASK                  0x01
 #define IA32_VMX_ENTRY_CTLS_LOAD_IA32_RTIT_CTL(_)                    (((_) >> 18) & 0x01)
-    uint64_t reserved4                                               : 1;
+
+    /**
+     * [Bit 19] This control determines whether UINV is loaded on VM entry.
+     */
+    uint64_t load_uinv                                               : 1;
+#define IA32_VMX_ENTRY_CTLS_LOAD_UINV_BIT                            19
+#define IA32_VMX_ENTRY_CTLS_LOAD_UINV_FLAG                           0x80000
+#define IA32_VMX_ENTRY_CTLS_LOAD_UINV_MASK                           0x01
+#define IA32_VMX_ENTRY_CTLS_LOAD_UINV(_)                             (((_) >> 19) & 0x01)
 
     /**
      * [Bit 20] This control determines whether CET-related MSRs and SPP are loaded on VM entry.
@@ -11587,7 +11611,7 @@ typedef union
 #define IA32_VMX_ENTRY_CTLS_LOAD_IA32_PKRS_FLAG                      0x400000
 #define IA32_VMX_ENTRY_CTLS_LOAD_IA32_PKRS_MASK                      0x01
 #define IA32_VMX_ENTRY_CTLS_LOAD_IA32_PKRS(_)                        (((_) >> 22) & 0x01)
-    uint64_t reserved5                                               : 41;
+    uint64_t reserved4                                               : 41;
   };
 
   uint64_t flags;
@@ -12126,7 +12150,17 @@ typedef union
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_XSAVES_FLAG                  0x100000
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_XSAVES_MASK                  0x01
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_XSAVES(_)                    (((_) >> 20) & 0x01)
-    uint64_t reserved1                                               : 1;
+
+    /**
+     * [Bit 21] If this control is 1, PASID translation is performed for executions of ENQCMD and ENQCMDS.
+     *
+     * @see Vol3C[27.5.8(PASID Translation)]
+     */
+    uint64_t enable_pasid_translation                                : 1;
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PASID_TRANSLATION_BIT        21
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PASID_TRANSLATION_FLAG       0x200000
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PASID_TRANSLATION_MASK       0x01
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PASID_TRANSLATION(_)         (((_) >> 21) & 0x01)
 
     /**
      * [Bit 22] If this control is 1, EPT execute permissions are based on whether the linear address being accessed is
@@ -12188,7 +12222,17 @@ typedef union
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_USER_WAIT_PAUSE_FLAG         0x4000000
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_USER_WAIT_PAUSE_MASK         0x01
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_USER_WAIT_PAUSE(_)           (((_) >> 26) & 0x01)
-    uint64_t reserved2                                               : 1;
+
+    /**
+     * @brief Enables the PCONFIG instruction
+     *
+     * [Bit 27] If this control is 0, any execution of PCONFIG causes a \#UD.
+     */
+    uint64_t enable_pconfig                                          : 1;
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PCONFIG_BIT                  27
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PCONFIG_FLAG                 0x8000000
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PCONFIG_MASK                 0x01
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PCONFIG(_)                   (((_) >> 27) & 0x01)
 
     /**
      * @brief Enables ENCLV VM-exits
@@ -12204,7 +12248,36 @@ typedef union
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_ENCLV_EXITING_FLAG           0x10000000
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_ENCLV_EXITING_MASK           0x01
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_ENCLV_EXITING(_)             (((_) >> 28) & 0x01)
-    uint64_t reserved3                                               : 35;
+    uint64_t reserved1                                               : 1;
+
+    /**
+     * @brief Enables VM-exits on bus lock assertions
+     *
+     * [Bit 30] This control determines whether assertion of a bus lock causes a VM exit.
+     *
+     * @see Vol3C[27.2(OTHER CAUSES OF VM EXIT)]
+     */
+    uint64_t enable_vmm_bus_lock_detection                           : 1;
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_VMM_BUS_LOCK_DETECTION_BIT   30
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_VMM_BUS_LOCK_DETECTION_FLAG  0x40000000
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_VMM_BUS_LOCK_DETECTION_MASK  0x01
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_VMM_BUS_LOCK_DETECTION(_)    (((_) >> 30) & 0x01)
+
+    /**
+     * @brief Enables VM-exits on instructions that block for a certain amount of time
+     *
+     * [Bit 31] If this control is 1, a VM exit occurs if certain operations prevent the processor from reaching an instruction
+     * boundary within a specified amount of time.
+     *
+     * @see Vol3C[26.6.25(Instruction-Timeout Contro)]
+     * @see Vol3C[27.2(OTHER CAUSES OF VM EXIT)]
+     */
+    uint64_t enable_instruction_timeout_exit                         : 1;
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_INSTRUCTION_TIMEOUT_EXIT_BIT 31
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_INSTRUCTION_TIMEOUT_EXIT_FLAG 0x80000000
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_INSTRUCTION_TIMEOUT_EXIT_MASK 0x01
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_INSTRUCTION_TIMEOUT_EXIT(_)  (((_) >> 31) & 0x01)
+    uint64_t reserved2                                               : 32;
   };
 
   uint64_t flags;
@@ -12571,7 +12644,47 @@ typedef union
 #define IA32_VMX_PROCBASED_CTLS3_GUEST_PAGING_FLAG                   0x08
 #define IA32_VMX_PROCBASED_CTLS3_GUEST_PAGING_MASK                   0x01
 #define IA32_VMX_PROCBASED_CTLS3_GUEST_PAGING(_)                     (((_) >> 3) & 0x01)
-    uint64_t reserved1                                               : 60;
+
+    /**
+     * @brief Enables virtualization of IPIs
+     *
+     * [Bit 4] If this control is 1, virtualization of interprocessor interrupts (IPIs) is enabled.
+     *
+     * @see Vol3C[31.1.6(IPI Virtualization)]
+     */
+    uint64_t enable_ipi_virtualization                               : 1;
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_IPI_VIRTUALIZATION_BIT       4
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_IPI_VIRTUALIZATION_FLAG      0x10
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_IPI_VIRTUALIZATION_MASK      0x01
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_IPI_VIRTUALIZATION(_)        (((_) >> 4) & 0x01)
+    uint64_t reserved1                                               : 1;
+
+    /**
+     * @brief Enables RDMSRLIST/WRMSRLIST instructions
+     *
+     * [Bit 6] If this control is 0, any execution of RDMSRLIST or WRMSRLIST causes a \#UD.
+     */
+    uint64_t enable_rdmsrlist_wrmsrlist                              : 1;
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_RDMSRLIST_WRMSRLIST_BIT      6
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_RDMSRLIST_WRMSRLIST_FLAG     0x40
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_RDMSRLIST_WRMSRLIST_MASK     0x01
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_RDMSRLIST_WRMSRLIST(_)       (((_) >> 6) & 0x01)
+
+    /**
+     * @brief Changes access to the IA32_SPEC_CTRL MSR
+     *
+     * [Bit 7] If this control is 1, the operation of the RDMSR and WRMSR instructions is changed when accessing the
+     * IA32_SPEC_CTRL MSR.
+     *
+     * @see Vol3C[26.6.26(Fields Controlling Virtualization of the IA32_SPEC_CTRL MSR)]
+     * @see Vol3C[27.3(CHANGES TO INSTRUCTION BEHAVIOR IN VMX NON-ROOT OPERATION)]
+     */
+    uint64_t virtualize_ia32_spec_ctrl                               : 1;
+#define IA32_VMX_PROCBASED_CTLS3_VIRTUALIZE_IA32_SPEC_CTRL_BIT       7
+#define IA32_VMX_PROCBASED_CTLS3_VIRTUALIZE_IA32_SPEC_CTRL_FLAG      0x80
+#define IA32_VMX_PROCBASED_CTLS3_VIRTUALIZE_IA32_SPEC_CTRL_MASK      0x01
+#define IA32_VMX_PROCBASED_CTLS3_VIRTUALIZE_IA32_SPEC_CTRL(_)        (((_) >> 7) & 0x01)
+    uint64_t reserved2                                               : 56;
   };
 
   uint64_t flags;
@@ -12590,11 +12703,22 @@ typedef union
 {
   struct
   {
-    uint64_t reserved                                                : 64;
-#define IA32_VMX_EXIT_CTLS2_RESERVED_BIT                             0
-#define IA32_VMX_EXIT_CTLS2_RESERVED_FLAG                            0xFFFFFFFFFFFFFFFF
-#define IA32_VMX_EXIT_CTLS2_RESERVED_MASK                            0xFFFFFFFFFFFFFFFF
-#define IA32_VMX_EXIT_CTLS2_RESERVED(_)                              (((_) >> 0) & 0xFFFFFFFFFFFFFFFF)
+    uint64_t reserved1                                               : 3;
+
+    /**
+     * @brief Enables indication of when a VM-exit causes a shadow stack to become prematurely busy
+     *
+     * [Bit 3] If this control is 1, VM exits that cause a shadow stack to become prematurely busy indicate this fact and save
+     * additional information into the VMCS.
+     *
+     * @see Vol1[18.2.3(Supervisor Shadow Stack Token)]
+     */
+    uint64_t enable_prematurely_busy_shadow_stack_indication         : 1;
+#define IA32_VMX_EXIT_CTLS2_ENABLE_PREMATURELY_BUSY_SHADOW_STACK_INDICATION_BIT 3
+#define IA32_VMX_EXIT_CTLS2_ENABLE_PREMATURELY_BUSY_SHADOW_STACK_INDICATION_FLAG 0x08
+#define IA32_VMX_EXIT_CTLS2_ENABLE_PREMATURELY_BUSY_SHADOW_STACK_INDICATION_MASK 0x01
+#define IA32_VMX_EXIT_CTLS2_ENABLE_PREMATURELY_BUSY_SHADOW_STACK_INDICATION(_) (((_) >> 3) & 0x01)
+    uint64_t reserved2                                               : 60;
   };
 
   uint64_t flags;
@@ -18032,6 +18156,128 @@ typedef struct
  * the following three values: EDX:EAX, the IA32_XSS MSR, and the XSS-exiting bitmap.
  */
 #define VMX_EXIT_REASON_EXECUTE_XRSTORS                              0x00000040
+
+/**
+ * @brief PCONFIG
+ *
+ * Guest software attempted to execute PCONFIG, "enable PCONFIG" VM-execution control was 1, and either (1) EAX < 63 and
+ * the corresponding bit in the PCONFIG-exiting bitmap is 1; or (2) EAX ? 63 and bit 63 in the PCONFIG-exiting bitmap is 1.
+ */
+#define VMX_EXIT_REASON_EXECUTE_PCONFIG                              0x00000041
+
+/**
+ * @brief SPP-related event
+ *
+ * SPP-related event. The processor attempted to determine an access's sub-page write permission and encountered an SPP
+ * miss or an SPP misconfiguration.
+ *
+ * @see Vol3C[30.3.4.2(Determining an Access's Sub-Page Write Permission)]
+ */
+#define VMX_EXIT_REASON_SPP_RELATED_EVENT                            0x00000042
+
+/**
+ * @brief UMWAIT
+ *
+ * Guest software attempted to execute UMWAIT and the "enable user wait and pause" and "RDTSC exiting" VM-execution
+ * controls were both 1.
+ */
+#define VMX_EXIT_REASON_EXECUTE_UMWAIT                               0x00000043
+
+/**
+ * @brief TPAUSE
+ *
+ * Guest software attempted to execute TPAUSE and the "enable user wait and pause" and "RDTSC exiting" VM-execution
+ * controls were both 1.
+ */
+#define VMX_EXIT_REASON_EXECUTE_TPAUSE                               0x00000044
+
+/**
+ * @brief LOADIWKEY
+ *
+ * Guest software attempted to execute LOADIWKEY and the "LOADIWKEY exiting" VM-execution control was 1.
+ */
+#define VMX_EXIT_REASON_EXECUTE_LOADIWKEY                            0x00000045
+
+/**
+ * @brief ENCLV
+ *
+ * Guest software attempted to execute ENCLV, the "enable ENCLV exiting" VM-execution control was 1, and either (1) EAX <
+ * 63 and the corresponding bit in the ENCLV-exiting bitmap is 1; or (2) EAX ? 63 and bit 63 in the ENCLV-exiting bitmap is
+ * 1.
+ */
+#define VMX_EXIT_REASON_EXECUTE_ENCLV                                0x00000046
+
+/**
+ * @brief ENQCMD PASID translation failure
+ *
+ * A VM exit occurred during PASID translation because the present bit was clear in a PASID-directory entry, the valid bit
+ * was clear in a PASID-table entry, or one of the entries set a reserved bit.
+ */
+#define VMX_EXIT_REASON_EXECUTE_ENQCMD                               0x00000048
+
+/**
+ * @brief ENQCMDS PASID translation failure
+ *
+ * A VM exit occurred during PASID translation because the present bit was clear in a PASID-directory entry, the valid bit
+ * was clear in a PASID-table entry, or one of the entries set a reserved bit.
+ */
+#define VMX_EXIT_REASON_EXECUTE_ENQCMDS                              0x00000049
+
+/**
+ * @brief Bus lock
+ *
+ * The processor asserted a bus lock while the "bus-lock detection" VM-execution control was 1. (Such VM exits will also
+ * set bit 26 of the exit-reason field.)
+ */
+#define VMX_EXIT_REASON_BUS_LOCK_ASSERTION                           0x0000004A
+
+/**
+ * @brief Instruction timeout
+ *
+ * The "instruction timeout" VM-execution control was 1 and certain operations prevented the processor from reaching an
+ * instruction boundary within the amount of time specified by the instruction-timeout control.
+ */
+#define VMX_EXIT_REASON_INSTRUCTION_TIMEOUT                          0x0000004B
+
+/**
+ * @brief SEAMCALL
+ *
+ * Guest software attempted to execute SEAMCALL.
+ */
+#define VMX_EXIT_REASON_EXECUTE_SEAMCALL                             0x0000004C
+
+/**
+ * @brief TDCALL
+ *
+ * Guest software attempted to execute TDCALL.
+ */
+#define VMX_EXIT_REASON_EXECUTE_TDCALL                               0x0000004D
+
+/**
+ * @brief RDMSRLIST
+ *
+ * Guest software attempted to execute RDMSRLIST and either the "use MSR bitmaps" VM-execution control was 0 or any of the
+ * following holds for the index an MSR being accessed:
+ * * The index is neither in the range 00000000H - 00001FFFH nor in the range C0000000H - C0001FFFH.
+ * * The index is in the range 00000000H - 00001FFFH and the nth bit in read bitmap for low MSRs is 1, where n is the
+ * index.
+ * * The index is in the range C0000000H - C0001FFFH and the nth bit in read bitmap for high MSRs is 1, where n is the
+ * logical AND of the index and the value 00001FFFH.
+ */
+#define VMX_EXIT_REASON_EXECUTE_RDMSRLIST                            0x0000004E
+
+/**
+ * @brief WRMSRLIST
+ *
+ * Guest software attempted to execute WRMSRLIST and either the "use MSR bitmaps" VM-execution control was 0 or any of the
+ * following holds for the index an MSR being accessed:
+ * * The index is neither in the range 00000000H - 00001FFFH nor in the range C0000000H - C0001FFFH.
+ * * The index is in the range 00000000H - 00001FFFH and the nth bit in write bitmap for low MSRs is 1, where n is the
+ * index.
+ * * The index is in the range C0000000H - C0001FFFH and the nth bit in write bitmap for high MSRs is 1, where n is the
+ * logical AND of the index and the value 00001FFFH.
+ */
+#define VMX_EXIT_REASON_EXECUTE_WRMSRLIST                            0x0000004F
 /**
  * @}
  */
@@ -21191,6 +21437,14 @@ typedef union
  * @remarks This field exists only on processors that support the 1-setting of the "enable HLAT" VM-execution control.
  */
 #define VMCS_CTRL_HLAT_PREFIX_SIZE                                   0x00000006
+
+/**
+ * Last PID-pointer index.
+ *
+ * @remarks This field exists only on processors that support the 1-setting of the "IPI virtualization" VM-execution
+ *          control
+ */
+#define VMCS_CTRL_LAST_PID_POINTER_INDEX                             0x00000008
 /**
  * @}
  */
@@ -21256,6 +21510,14 @@ typedef union
  * @remarks This field exists only on processors that support the 1-setting of the "enable PML" VM-execution control.
  */
 #define VMCS_GUEST_PML_INDEX                                         0x00000812
+
+/**
+ * UINV.
+ *
+ * @remarks This field exists only on processors that support the 1-setting of either the "clear UINV" VM-exit control or
+ *          the "load UINV" VM-entry control.
+ */
+#define VMCS_GUEST_UINV                                              0x00000814
 /**
  * @}
  */
@@ -21466,14 +21728,49 @@ typedef union
 #define VMCS_CTRL_ENCLV_EXITING_BITMAP                               0x00002036
 
 /**
+ * Low PASID directory address.
+ */
+#define VMCS_CTRL_LOW_PASID_DIRECTORY_ADDRESS                        0x00002038
+
+/**
+ * High PASID directory address.
+ */
+#define VMCS_CTRL_HIGH_PASID_DIRECTORY_ADDRESS                       0x0000203A
+
+/**
+ * Shared EPT pointer.
+ */
+#define VMCS_CTRL_SHARED_EPT_POINTER                                 0x0000203C
+
+/**
+ * PCONFIG-exiting bitmap.
+ */
+#define VMCS_CTRL_PCONFIG_EXITING_BITMAP                             0x0000203E
+
+/**
  * Hypervisor-managed linear-address translation pointer.
  */
 #define VMCS_CTRL_HLAT_POINTER                                       0x00002040
 
 /**
+ * PID-pointer table address.
+ */
+#define VMCS_CTRL_PID_POINTER_TABLE_ADDRESS                          0x00002042
+
+/**
  * Secondary VM-exit controls.
  */
 #define VMCS_CTRL_SECONDARY_VMEXIT_CONTROLS                          0x00002044
+
+/**
+ * IA32_SPEC_CTRL mask.
+ */
+#define VMCS_CTRL_IA32_SPEC_CTRL_MASK                                0x0000204A
+
+/**
+ * IA32_SPEC_CTRL shadow.
+ */
+#define VMCS_CTRL_IA32_SPEC_CTRL_SHADOW                              0x0000204C
 /**
  * @}
  */
@@ -22114,17 +22411,17 @@ typedef union
 /**
  * Guest IA32_S_CET.
  */
-#define VMCS_GUEST_S_CET                                             0x00006C28
+#define VMCS_GUEST_S_CET                                             0x00006828
 
 /**
  * Guest SSP.
  */
-#define VMCS_GUEST_SSP                                               0x00006C2A
+#define VMCS_GUEST_SSP                                               0x0000682A
 
 /**
  * Guest IA32_INTERRUPT_SSP_TABLE_ADDR.
  */
-#define VMCS_GUEST_INTERRUPT_SSP_TABLE_ADDR                          0x00006C2C
+#define VMCS_GUEST_INTERRUPT_SSP_TABLE_ADDR                          0x0000682C
 /**
  * @}
  */

--- a/out/ia32_compact.h
+++ b/out/ia32_compact.h
@@ -3004,10 +3004,10 @@ typedef union {
     uint64_t conceal_vmx_from_pt                                     : 1;
     uint64_t clear_ia32_rtit_ctl                                     : 1;
     uint64_t clear_ia32_lbr_ctl                                      : 1;
-    uint64_t reserved_6                                              : 1;
+    uint64_t clear_uinv                                              : 1;
     uint64_t load_ia32_cet_state                                     : 1;
     uint64_t load_ia32_pkrs                                          : 1;
-    uint64_t reserved_7                                              : 1;
+    uint64_t save_ia32_perf_global_ctl                               : 1;
     uint64_t activate_secondary_controls                             : 1;
   };
 
@@ -3030,7 +3030,7 @@ typedef union {
     uint64_t load_ia32_bndcfgs                                       : 1;
     uint64_t conceal_vmx_from_pt                                     : 1;
     uint64_t load_ia32_rtit_ctl                                      : 1;
-    uint64_t reserved_4                                              : 1;
+    uint64_t load_uinv                                               : 1;
     uint64_t load_cet_state                                          : 1;
     uint64_t load_ia32_lbr_ctl                                       : 1;
     uint64_t load_ia32_pkrs                                          : 1;
@@ -3101,14 +3101,17 @@ typedef union {
     uint64_t ept_violation                                           : 1;
     uint64_t conceal_vmx_from_pt                                     : 1;
     uint64_t enable_xsaves                                           : 1;
-    uint64_t reserved_1                                              : 1;
+    uint64_t enable_pasid_translation                                : 1;
     uint64_t mode_based_execute_control_for_ept                      : 1;
     uint64_t sub_page_write_permissions_for_ept                      : 1;
     uint64_t pt_uses_guest_physical_addresses                        : 1;
     uint64_t use_tsc_scaling                                         : 1;
     uint64_t enable_user_wait_pause                                  : 1;
-    uint64_t reserved_2                                              : 1;
+    uint64_t enable_pconfig                                          : 1;
     uint64_t enable_enclv_exiting                                    : 1;
+    uint64_t reserved_1                                              : 1;
+    uint64_t enable_vmm_bus_lock_detection                           : 1;
+    uint64_t enable_instruction_timeout_exit                         : 1;
   };
 
   uint64_t flags;
@@ -3187,6 +3190,10 @@ typedef union {
     uint64_t enable_hlat                                             : 1;
     uint64_t ept_paging_write                                        : 1;
     uint64_t guest_paging                                            : 1;
+    uint64_t enable_ipi_virtualization                               : 1;
+    uint64_t reserved_1                                              : 1;
+    uint64_t enable_rdmsrlist_wrmsrlist                              : 1;
+    uint64_t virtualize_ia32_spec_ctrl                               : 1;
   };
 
   uint64_t flags;
@@ -3195,7 +3202,8 @@ typedef union {
 #define IA32_VMX_EXIT_CTLS2                                          0x00000493
 typedef union {
   struct {
-    uint64_t reserved                                                : 64;
+    uint64_t reserved_1                                              : 3;
+    uint64_t enable_prematurely_busy_shadow_stack_indication         : 1;
   };
 
   uint64_t flags;
@@ -4256,6 +4264,20 @@ typedef struct {
 #define VMX_EXIT_REASON_PML_FULL                                     0x0000003E
 #define VMX_EXIT_REASON_XSAVES                                       0x0000003F
 #define VMX_EXIT_REASON_XRSTORS                                      0x00000040
+#define VMX_EXIT_REASON_PCONFIG                                      0x00000041
+#define VMX_EXIT_REASON_SPP_EVENT                                    0x00000042
+#define VMX_EXIT_REASON_UMWAIT                                       0x00000043
+#define VMX_EXIT_REASON_TPAUSE                                       0x00000044
+#define VMX_EXIT_REASON_LOADIWKEY                                    0x00000045
+#define VMX_EXIT_REASON_ENCLV                                        0x00000046
+#define VMX_EXIT_REASON_ENQCMD                                       0x00000048
+#define VMX_EXIT_REASON_ENQCMDS                                      0x00000049
+#define VMX_EXIT_REASON_BUS_LOCK                                     0x0000004A
+#define VMX_EXIT_REASON_INSTRUCTION_TIMEOUT                          0x0000004B
+#define VMX_EXIT_REASON_SEAMCALL                                     0x0000004C
+#define VMX_EXIT_REASON_TDCALL                                       0x0000004D
+#define VMX_EXIT_REASON_RDMSRLIST                                    0x0000004E
+#define VMX_EXIT_REASON_WRMSRLIST                                    0x0000004F
 /**
  * @}
  */
@@ -4963,6 +4985,7 @@ typedef union {
 #define VMCS_CTRL_POSTED_INTR_NOTIFY_VECTOR                          0x00000002
 #define VMCS_CTRL_EPTP_INDEX                                         0x00000004
 #define VMCS_CTRL_HLAT_PREFIX_SIZE                                   0x00000006
+#define VMCS_CTRL_LAST_PID_PTR_INDEX                                 0x00000008
 /**
  * @}
  */
@@ -4982,6 +5005,7 @@ typedef union {
 #define VMCS_GUEST_TR_SEL                                            0x0000080E
 #define VMCS_GUEST_INTR_STATUS                                       0x00000810
 #define VMCS_GUEST_PML_INDEX                                         0x00000812
+#define VMCS_GUEST_UINV                                              0x00000814
 /**
  * @}
  */
@@ -5044,8 +5068,15 @@ typedef union {
 #define VMCS_CTRL_TSC_MULTIPLIER                                     0x00002032
 #define VMCS_CTRL_PROC_EXEC3                                         0x00002034
 #define VMCS_CTRL_ENCLV_EXITING_BITMAP                               0x00002036
+#define VMCS_CTRL_LOW_PASID_DIR_ADDR                                 0x00002038
+#define VMCS_CTRL_HIGH_PASID_DIR_ADDR                                0x0000203A
+#define VMCS_CTRL_SHARED_EPTP                                        0x0000203C
+#define VMCS_CTRL_PCONFIG_BITMAP                                     0x0000203E
 #define VMCS_CTRL_HLATP                                              0x00002040
+#define VMCS_CTRL_PID_PTR_TABLE                                      0x00002042
 #define VMCS_CTRL_SECONDARY_EXIT                                     0x00002044
+#define VMCS_CTRL_SPEC_CTRL_MASK                                     0x0000204A
+#define VMCS_CTRL_SPEC_CTRL_SHADOW                                   0x0000204C
 /**
  * @}
  */
@@ -5256,9 +5287,9 @@ typedef union {
 #define VMCS_GUEST_PENDING_DEBUG_EXCEPTIONS                          0x00006822
 #define VMCS_GUEST_SYSENTER_ESP                                      0x00006824
 #define VMCS_GUEST_SYSENTER_EIP                                      0x00006826
-#define VMCS_GUEST_S_CET                                             0x00006C28
-#define VMCS_GUEST_SSP                                               0x00006C2A
-#define VMCS_GUEST_INTERRUPT_SSP_TABLE_ADDR                          0x00006C2C
+#define VMCS_GUEST_S_CET                                             0x00006828
+#define VMCS_GUEST_SSP                                               0x0000682A
+#define VMCS_GUEST_INTERRUPT_SSP_TABLE_ADDR                          0x0000682C
 /**
  * @}
  */

--- a/out/ia32_defines_only.h
+++ b/out/ia32_defines_only.h
@@ -3839,15 +3839,17 @@ typedef union {
 #define IA32_VMX_EXIT_CTLS_CLEAR_IA32_RTIT_CTL                       0x2000000
     uint64_t clear_ia32_lbr_ctl                                      : 1;
 #define IA32_VMX_EXIT_CTLS_CLEAR_IA32_LBR_CTL                        0x4000000
-    uint64_t reserved_6                                              : 1;
+    uint64_t clear_uinv                                              : 1;
+#define IA32_VMX_EXIT_CTLS_CLEAR_UINV                                0x8000000
     uint64_t load_ia32_cet_state                                     : 1;
 #define IA32_VMX_EXIT_CTLS_LOAD_IA32_CET_STATE                       0x10000000
     uint64_t load_ia32_pkrs                                          : 1;
 #define IA32_VMX_EXIT_CTLS_LOAD_IA32_PKRS                            0x20000000
-    uint64_t reserved_7                                              : 1;
+    uint64_t save_ia32_perf_global_ctl                               : 1;
+#define IA32_VMX_EXIT_CTLS_SAVE_IA32_PERF_GLOBAL_CTL                 0x40000000
     uint64_t activate_secondary_controls                             : 1;
 #define IA32_VMX_EXIT_CTLS_ACTIVATE_SECONDARY_CONTROLS               0x80000000
-    uint64_t reserved_8                                              : 32;
+    uint64_t reserved_6                                              : 32;
   };
 
   uint64_t Flags;
@@ -3879,14 +3881,15 @@ typedef union {
 #define IA32_VMX_ENTRY_CTLS_CONCEAL_VMX_FROM_PT                      0x20000
     uint64_t load_ia32_rtit_ctl                                      : 1;
 #define IA32_VMX_ENTRY_CTLS_LOAD_IA32_RTIT_CTL                       0x40000
-    uint64_t reserved_4                                              : 1;
+    uint64_t load_uinv                                               : 1;
+#define IA32_VMX_ENTRY_CTLS_LOAD_UINV                                0x80000
     uint64_t load_cet_state                                          : 1;
 #define IA32_VMX_ENTRY_CTLS_LOAD_CET_STATE                           0x100000
     uint64_t load_ia32_lbr_ctl                                       : 1;
 #define IA32_VMX_ENTRY_CTLS_LOAD_IA32_LBR_CTL                        0x200000
     uint64_t load_ia32_pkrs                                          : 1;
 #define IA32_VMX_ENTRY_CTLS_LOAD_IA32_PKRS                           0x400000
-    uint64_t reserved_5                                              : 41;
+    uint64_t reserved_4                                              : 41;
   };
 
   uint64_t Flags;
@@ -3991,7 +3994,8 @@ typedef union {
 #define IA32_VMX_PROCBASED_CTLS2_CONCEAL_VMX_FROM_PT                 0x80000
     uint64_t enable_xsaves                                           : 1;
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_XSAVES                       0x100000
-    uint64_t reserved_1                                              : 1;
+    uint64_t enable_pasid_translation                                : 1;
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PASID_TRANSLATION            0x200000
     uint64_t mode_based_execute_control_for_ept                      : 1;
 #define IA32_VMX_PROCBASED_CTLS2_MODE_BASED_EXECUTE_CONTROL_FOR_EPT  0x400000
     uint64_t sub_page_write_permissions_for_ept                      : 1;
@@ -4002,10 +4006,16 @@ typedef union {
 #define IA32_VMX_PROCBASED_CTLS2_USE_TSC_SCALING                     0x2000000
     uint64_t enable_user_wait_pause                                  : 1;
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_USER_WAIT_PAUSE              0x4000000
-    uint64_t reserved_2                                              : 1;
+    uint64_t enable_pconfig                                          : 1;
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_PCONFIG                      0x8000000
     uint64_t enable_enclv_exiting                                    : 1;
 #define IA32_VMX_PROCBASED_CTLS2_ENABLE_ENCLV_EXITING                0x10000000
-    uint64_t reserved_3                                              : 35;
+    uint64_t reserved_1                                              : 1;
+    uint64_t enable_vmm_bus_lock_detection                           : 1;
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_VMM_BUS_LOCK_DETECTION       0x40000000
+    uint64_t enable_instruction_timeout_exit                         : 1;
+#define IA32_VMX_PROCBASED_CTLS2_ENABLE_INSTRUCTION_TIMEOUT_EXIT     0x80000000
+    uint64_t reserved_2                                              : 32;
   };
 
   uint64_t Flags;
@@ -4111,7 +4121,14 @@ typedef union {
 #define IA32_VMX_PROCBASED_CTLS3_EPT_PAGING_WRITE                    0x04
     uint64_t guest_paging                                            : 1;
 #define IA32_VMX_PROCBASED_CTLS3_GUEST_PAGING                        0x08
-    uint64_t reserved_1                                              : 60;
+    uint64_t enable_ipi_virtualization                               : 1;
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_IPI_VIRTUALIZATION           0x10
+    uint64_t reserved_1                                              : 1;
+    uint64_t enable_rdmsrlist_wrmsrlist                              : 1;
+#define IA32_VMX_PROCBASED_CTLS3_ENABLE_RDMSRLIST_WRMSRLIST          0x40
+    uint64_t virtualize_ia32_spec_ctrl                               : 1;
+#define IA32_VMX_PROCBASED_CTLS3_VIRTUALIZE_IA32_SPEC_CTRL           0x80
+    uint64_t reserved_2                                              : 56;
   };
 
   uint64_t Flags;
@@ -4120,8 +4137,10 @@ typedef union {
 #define IA32_VMX_EXIT_CTLS2                                          0x00000493
 typedef union {
   struct {
-    uint64_t reserved                                                : 64;
-#define IA32_VMX_EXIT_CTLS2_RESERVED                                 0xFFFFFFFFFFFFFFFF
+    uint64_t reserved_1                                              : 3;
+    uint64_t enable_prematurely_busy_shadow_stack_indication         : 1;
+#define IA32_VMX_EXIT_CTLS2_ENABLE_PREMATURELY_BUSY_SHADOW_STACK_INDICATION 0x08
+    uint64_t reserved_2                                              : 60;
   };
 
   uint64_t Flags;
@@ -5490,6 +5509,20 @@ typedef struct {
 #define VMX_EXIT_REASON_PML_FULL                                     0x0000003E
 #define VMX_EXIT_REASON_XSAVES                                       0x0000003F
 #define VMX_EXIT_REASON_XRSTORS                                      0x00000040
+#define VMX_EXIT_REASON_PCONFIG                                      0x00000041
+#define VMX_EXIT_REASON_SPP_EVENT                                    0x00000042
+#define VMX_EXIT_REASON_UMWAIT                                       0x00000043
+#define VMX_EXIT_REASON_TPAUSE                                       0x00000044
+#define VMX_EXIT_REASON_LOADIWKEY                                    0x00000045
+#define VMX_EXIT_REASON_ENCLV                                        0x00000046
+#define VMX_EXIT_REASON_ENQCMD                                       0x00000048
+#define VMX_EXIT_REASON_ENQCMDS                                      0x00000049
+#define VMX_EXIT_REASON_BUS_LOCK                                     0x0000004A
+#define VMX_EXIT_REASON_INSTRUCTION_TIMEOUT                          0x0000004B
+#define VMX_EXIT_REASON_SEAMCALL                                     0x0000004C
+#define VMX_EXIT_REASON_TDCALL                                       0x0000004D
+#define VMX_EXIT_REASON_RDMSRLIST                                    0x0000004E
+#define VMX_EXIT_REASON_WRMSRLIST                                    0x0000004F
 /**
  * @}
  */
@@ -6422,6 +6455,7 @@ typedef union {
 #define VMCS_CTRL_POSTED_INTR_NOTIFY_VECTOR                          0x00000002
 #define VMCS_CTRL_EPTP_INDEX                                         0x00000004
 #define VMCS_CTRL_HLAT_PREFIX_SIZE                                   0x00000006
+#define VMCS_CTRL_LAST_PID_PTR_INDEX                                 0x00000008
 /**
  * @}
  */
@@ -6441,6 +6475,7 @@ typedef union {
 #define VMCS_GUEST_TR_SEL                                            0x0000080E
 #define VMCS_GUEST_INTR_STATUS                                       0x00000810
 #define VMCS_GUEST_PML_INDEX                                         0x00000812
+#define VMCS_GUEST_UINV                                              0x00000814
 /**
  * @}
  */
@@ -6503,8 +6538,15 @@ typedef union {
 #define VMCS_CTRL_TSC_MULTIPLIER                                     0x00002032
 #define VMCS_CTRL_PROC_EXEC3                                         0x00002034
 #define VMCS_CTRL_ENCLV_EXITING_BITMAP                               0x00002036
+#define VMCS_CTRL_LOW_PASID_DIR_ADDR                                 0x00002038
+#define VMCS_CTRL_HIGH_PASID_DIR_ADDR                                0x0000203A
+#define VMCS_CTRL_SHARED_EPTP                                        0x0000203C
+#define VMCS_CTRL_PCONFIG_BITMAP                                     0x0000203E
 #define VMCS_CTRL_HLATP                                              0x00002040
+#define VMCS_CTRL_PID_PTR_TABLE                                      0x00002042
 #define VMCS_CTRL_SECONDARY_EXIT                                     0x00002044
+#define VMCS_CTRL_SPEC_CTRL_MASK                                     0x0000204A
+#define VMCS_CTRL_SPEC_CTRL_SHADOW                                   0x0000204C
 /**
  * @}
  */
@@ -6715,9 +6757,9 @@ typedef union {
 #define VMCS_GUEST_PENDING_DEBUG_EXCEPTIONS                          0x00006822
 #define VMCS_GUEST_SYSENTER_ESP                                      0x00006824
 #define VMCS_GUEST_SYSENTER_EIP                                      0x00006826
-#define VMCS_GUEST_S_CET                                             0x00006C28
-#define VMCS_GUEST_SSP                                               0x00006C2A
-#define VMCS_GUEST_INTERRUPT_SSP_TABLE_ADDR                          0x00006C2C
+#define VMCS_GUEST_S_CET                                             0x00006828
+#define VMCS_GUEST_SSP                                               0x0000682A
+#define VMCS_GUEST_INTERRUPT_SSP_TABLE_ADDR                          0x0000682C
 /**
  * @}
  */

--- a/yaml/Intel/ModelSpecificRegisters/ArchitecturalMsr.yml
+++ b/yaml/Intel/ModelSpecificRegisters/ArchitecturalMsr.yml
@@ -3412,6 +3412,11 @@
       long_name: CLEAR_IA32_LBR_CTL
       description: This control determines whether the IA32_LBR_CTL MSR is cleared on VM exit.
 
+    - bit: 27
+      short_name: CLEAR_UINV
+      long_name: CLEAR_UINV
+      description: This control determines whether UINV is cleared on VM exit.
+
     - bit: 28
       short_name: LOAD_HOST_CET_STATE
       long_name: LOAD_IA32_CET_STATE
@@ -3424,6 +3429,13 @@
       long_name: LOAD_IA32_PKRS
       description: |
         This control determines whether the IA32_PKRS MSR is loaded on VM exit.
+    
+    - bit: 30
+      short_name: SAVE_PERF_GLOBAL_CTL
+      long_name: SAVE_IA32_PERF_GLOBAL_CTL
+      description: |
+        This control determines whether the IA32_PERF_GLOBAL_CTL MSR is saved on VM
+        exit.
 
     - bit: 31
       short_name: USE_SECONDARY_CONTROLS
@@ -4226,8 +4238,14 @@
     type: bitfield
     size: 64
     fields:
-    - bit: 0-63
-      name: RESERVED
+    - bit: 3
+      short_name: PREMATURELY_BUSY_SHADOW_STACK
+      long_name: ENABLE_PREMATURELY_BUSY_SHADOW_STACK_INDICATION
+      short_description: Enables indication of when a VM-exit causes a shadow stack to become prematurely busy.
+      long_description: |
+        If this control is 1, VM exits that cause a shadow stack to become prematurely busy
+        indicate this fact and save additional information into the VMCS.
+      see: Vol1[18.2.3(Supervisor Shadow Stack Token)]
 
 #
 # END-OF-VMX

--- a/yaml/Intel/ModelSpecificRegisters/ArchitecturalMsr.yml
+++ b/yaml/Intel/ModelSpecificRegisters/ArchitecturalMsr.yml
@@ -3924,6 +3924,13 @@
       long_description: |
         If this control is 0, any execution of XSAVES or XRSTORS causes a #UD.
 
+    - bit: 21
+      short_name: PASID_TRANSLATION
+      long_name: ENABLE_PASID_TRANSLATION
+      description: |
+        If this control is 1, PASID translation is performed for executions of ENQCMD and ENQCMDS.
+      see: Vol3C[27.5.8(PASID Translation)]
+
     - bit: 22
       short_name: MB_EXEC_CTL_EPT
       long_name: MODE_BASED_EXECUTE_CONTROL_FOR_EPT
@@ -3966,6 +3973,13 @@
       long_description: |
         If this control is 0, any execution of TPAUSE, UMONITOR, or UMWAIT causes a #UD.
 
+    - bit: 27
+      short_name: PCONFIG
+      long_name: ENABLE_PCONFIG
+      short_description: Enables the PCONFIG instruction.
+      long_description: |
+        If this control is 0, any execution of PCONFIG causes a #UD.
+
     - bit: 28
       short_name: ENCLV_EXIT
       long_name: ENABLE_ENCLV_EXITING
@@ -3976,6 +3990,26 @@
       see:
         - Vol3C[24.6.17(ENCLV-Exiting Bitmap)]
         - Vol3C[25.1.3(Instructions That Cause VM Exits Conditionally)]
+    
+    - bit: 30
+      short_name: BUS_LOCK_EXIT
+      long_name: ENABLE_VMM_BUS_LOCK_DETECTION
+      short_description: Enables VM-exits on bus lock assertions.
+      long_description: |
+        This control determines whether assertion of a bus lock causes a VM exit.
+      see:
+        - Vol3C[27.2(OTHER CAUSES OF VM EXIT)]
+    
+    - bit: 31
+      short_name: INSTRUCTION_TIMEOUT
+      long_name: ENABLE_INSTRUCTION_TIMEOUT_EXIT
+      short_description: Enables VM-exits on instructions that block for a certain amount of time.
+      long_description: |
+        If this control is 1, a VM exit occurs if certain operations prevent the processor from reaching an
+        instruction boundary within a specified amount of time.
+      see:
+        - Vol3C[26.6.25(Instruction-Timeout Contro)]
+        - Vol3C[27.2(OTHER CAUSES OF VM EXIT)]
 
 - value: 0x48C
   name: VMX_EPT_VPID_CAP
@@ -4228,6 +4262,35 @@
         If this control is 1, EPT permissions can be specified to prevent accesses using linear addresses
         verification whose translation has certain properties.
       see: Vol3C[28.3.3.2(EPT Violations)]
+    
+    - bit: 4
+      short_name: IPI_VIRTUALIZATION
+      long_name: ENABLE_IPI_VIRTUALIZATION
+      short_description: |
+        Enables virtualization of IPIs.
+      long_description: |
+        If this control is 1, virtualization of interprocessor interrupts (IPIs) is enabled.
+      see: Vol3C[31.1.6(IPI Virtualization)]
+
+    - bit: 6
+      short_name: MSRLIST
+      long_name: ENABLE_RDMSRLIST_WRMSRLIST
+      short_description: |
+        Enables RDMSRLIST/WRMSRLIST instructions.
+      long_description: |
+        If this control is 0, any execution of RDMSRLIST or WRMSRLIST causes a #UD.
+    
+    - bit: 7
+      short_name: VIRTUALIZE_SPEC_CTRL
+      long_name: VIRTUALIZE_IA32_SPEC_CTRL
+      short_description: |
+        Changes access to the IA32_SPEC_CTRL MSR.
+      long_description: |
+        If this control is 1, the operation of the RDMSR and WRMSR instructions is changed when
+        accessing the IA32_SPEC_CTRL MSR.
+      see: 
+        - Vol3C[26.6.26(Fields Controlling Virtualization of the IA32_SPEC_CTRL MSR)]
+        - Vol3C[27.3(CHANGES TO INSTRUCTION BEHAVIOR IN VMX NON-ROOT OPERATION)]
 
 - value: 0x493
   name: VMX_EXIT_CTLS2

--- a/yaml/Intel/ModelSpecificRegisters/ArchitecturalMsr.yml
+++ b/yaml/Intel/ModelSpecificRegisters/ArchitecturalMsr.yml
@@ -3531,6 +3531,10 @@
       long_name: LOAD_IA32_RTIT_CTL
       description: This control determines whether the IA32_RTIT_CTL MSR is loaded on VM entry.
 
+    - bit: 19
+      name: LOAD_UINV
+      description: This control determines whether UINV is loaded on VM entry.
+
     - bit: 20
       name: LOAD_CET_STATE
       description: This control determines whether CET-related MSRs and SPP are loaded on VM entry.

--- a/yaml/Intel/VMX/VMCS.yml
+++ b/yaml/Intel/VMX/VMCS.yml
@@ -209,6 +209,13 @@
         description: HLAT prefix size.
         remarks: |
           This field exists only on processors that support the 1-setting of the “enable HLAT” VM-execution control.
+      
+      - value: 0x0008
+        short_name: LAST_PID_PTR_INDEX
+        long_name: LAST_PID_POINTER_INDEX
+        description: Last PID-pointer index.
+        remarks: |
+          This field exists only on processors that support the 1-setting of the “IPI virtualization” VM-execution control
 
     - name: 16_BIT_GUEST_STATE_FIELDS
       description: 16-Bit Guest-State Fields.
@@ -268,6 +275,14 @@
         description: PML index.
         remarks: |
           This field exists only on processors that support the 1-setting of the “enable PML” VM-execution control.
+      
+      - value: 0x0814
+        short_name: UINV
+        long_name: UINV
+        description: UINV.
+        remarks: |
+          This field exists only on processors that support the 1-setting of either the “clear UINV” VM-exit control or the “load UINV” VM-entry
+          control.
 
     - name: 16_BIT_HOST_STATE_FIELDS
       description: 16-Bit Host-State Fields.
@@ -463,16 +478,51 @@
           short_name: ENCLV_EXITING_BITMAP
           long_name: ENCLV_EXITING_BITMAP
           description: ENCLV-exiting bitmap.
+        
+        - value: 0x2038
+          short_name: LOW_PASID_DIR_ADDR
+          long_name: LOW_PASID_DIRECTORY_ADDRESS
+          description: Low PASID directory address.
+        
+        - value: 0x203A
+          short_name: HIGH_PASID_DIR_ADDR
+          long_name: HIGH_PASID_DIRECTORY_ADDRESS
+          description: High PASID directory address.
+        
+        - value: 0x203C
+          short_name: SHARED_EPTP
+          long_name: SHARED_EPT_POINTER
+          description: Shared EPT pointer.
+        
+        - value: 0x203E
+          short_name: PCONFIG_BITMAP
+          long_name: PCONFIG_EXITING_BITMAP
+          description: PCONFIG-exiting bitmap.
 
         - value: 0x2040
           short_name: HLATP
           long_name: HLAT_POINTER
           description: Hypervisor-managed linear-address translation pointer.
+        
+        - value: 0x2042
+          short_name: PID_PTR_TABLE
+          long_name: PID_POINTER_TABLE_ADDRESS
+          description: PID-pointer table address.
 
         - value: 0x2044
           short_name: SECONDARY_EXIT
           long_name: SECONDARY_VMEXIT_CONTROLS
           description: Secondary VM-exit controls.
+        
+        - value: 0x204A
+          short_name: SPEC_CTRL_MASK
+          long_name: IA32_SPEC_CTRL_MASK
+          description: IA32_SPEC_CTRL mask.
+        
+        - value: 0x204C
+          short_name: SPEC_CTRL_SHADOW
+          long_name: IA32_SPEC_CTRL_SHADOW
+          description: IA32_SPEC_CTRL shadow.
 
       - name: 64_BIT_READ_ONLY_DATA_FIELDS
         description: 64-Bit Read-Only Data Field.

--- a/yaml/Intel/VMX/VMCS.yml
+++ b/yaml/Intel/VMX/VMCS.yml
@@ -1046,17 +1046,17 @@
           long_name: SYSENTER_EIP
           description: Guest IA32_SYSENTER_EIP.
 
-        - value: 0x6C28
+        - value: 0x6828
           short_name: S_CET
           long_name: S_CET
           description: Guest IA32_S_CET.
 
-        - value: 0x6C2A
+        - value: 0x682A
           short_name: SSP
           long_name: SSP
           description: Guest SSP.
 
-        - value: 0x6C2C
+        - value: 0x682C
           short_name: INTERRUPT_SSP_TABLE_ADDR
           long_name: INTERRUPT_SSP_TABLE_ADDR
           description: Guest IA32_INTERRUPT_SSP_TABLE_ADDR.

--- a/yaml/Intel/VMX/index.yml
+++ b/yaml/Intel/VMX/index.yml
@@ -524,6 +524,135 @@
         long_description: |
           Guest software attempted to execute XRSTORS, the “enable XSAVES/XRSTORS” was 1, and a bit was set
           in the logical-AND of the following three values: EDX:EAX, the IA32_XSS MSR, and the XSS-exiting bitmap.
+      
+      - value: 65
+        short_name: PCONFIG
+        long_name: EXECUTE_PCONFIG
+        short_description: PCONFIG
+        long_description: |
+          Guest software attempted to execute PCONFIG, “enable PCONFIG” VM-execution control was 1, and either
+          (1) EAX < 63 and the corresponding bit in the PCONFIG-exiting bitmap is 1; or (2) EAX ? 63 and bit 63 in the
+          PCONFIG-exiting bitmap is 1.
+
+      - value: 66
+        short_name: SPP_EVENT
+        long_name: SPP_RELATED_EVENT
+        short_description: SPP-related event.
+        long_description: |
+          SPP-related event. The processor attempted to determine an access’s sub-page write permission and encountered
+          an SPP miss or an SPP misconfiguration.
+        see: Vol3C[30.3.4.2(Determining an Access’s Sub-Page Write Permission)]
+
+      - value: 67
+        short_name: UMWAIT
+        long_name: EXECUTE_UMWAIT
+        short_description: UMWAIT
+        long_description: |
+          Guest software attempted to execute UMWAIT and the “enable user wait and pause” and “RDTSC exiting”
+          VM-execution controls were both 1.
+
+      - value: 68
+        short_name: TPAUSE
+        long_name: EXECUTE_TPAUSE
+        short_description: TPAUSE
+        long_description: |
+          Guest software attempted to execute TPAUSE and the “enable user wait and pause” and “RDTSC exiting”
+          VM-execution controls were both 1.
+
+      - value: 69
+        short_name: LOADIWKEY
+        long_name: EXECUTE_LOADIWKEY
+        short_description: LOADIWKEY
+        long_description: |
+          Guest software attempted to execute LOADIWKEY and the “LOADIWKEY exiting” VM-execution control
+          was 1.
+
+      - value: 70
+        short_name: ENCLV
+        long_name: EXECUTE_ENCLV
+        short_description: ENCLV
+        long_description: |
+          Guest software attempted to execute ENCLV, the “enable ENCLV exiting” VM-execution control was 1, and
+          either (1) EAX < 63 and the corresponding bit in the ENCLV-exiting bitmap is 1; or (2) EAX ? 63 and bit 63 in the
+          ENCLV-exiting bitmap is 1.
+
+      - value: 72
+        short_name: ENQCMD
+        long_name: EXECUTE_ENQCMD
+        short_description: ENQCMD PASID translation failure.
+        long_description: |
+          A VM exit occurred during PASID translation because the present bit was clear in a PASID-directory entry, the valid
+          bit was clear in a PASID-table entry, or one of the entries set a reserved bit.
+
+      - value: 73
+        short_name: ENQCMDS
+        long_name: EXECUTE_ENQCMDS
+        short_description: ENQCMDS PASID translation failure.
+        long_description: |
+          A VM exit occurred during PASID translation because the present bit was clear in a PASID-directory entry, the valid
+          bit was clear in a PASID-table entry, or one of the entries set a reserved bit.
+
+      - value: 74
+        short_name: BUS_LOCK
+        long_name: BUS_LOCK_ASSERTION
+        short_description: Bus lock
+        long_description: |
+          The processor asserted a bus lock while the “bus-lock detection” VM-execution control was 1. (Such VM exits will also
+          set bit 26 of the exit-reason field.)
+
+      - value: 75
+        short_name: INSTRUCTION_TIMEOUT
+        long_name: INSTRUCTION_TIMEOUT
+        short_description: Instruction timeout.
+        long_description: |
+          The “instruction timeout” VM-execution control was 1 and certain operations prevented the processor from reaching an
+          instruction boundary within the amount of time specified by the instruction-timeout control.
+
+      - value: 76
+        short_name: SEAMCALL
+        long_name: EXECUTE_SEAMCALL
+        short_description: SEAMCALL
+        long_description: |
+          Guest software attempted to execute SEAMCALL.
+
+      - value: 77
+        short_name: TDCALL
+        long_name: EXECUTE_TDCALL
+        short_description: TDCALL
+        long_description: |
+          Guest software attempted to execute TDCALL.
+
+      - value: 78
+        short_name: RDMSRLIST
+        long_name: EXECUTE_RDMSRLIST
+        short_description: RDMSRLIST
+        long_description: |
+          Guest software attempted to execute RDMSRLIST and either the “use MSR bitmaps” VM-execution
+          control was 0 or any of the following holds for the index an MSR being accessed:
+
+          • The index is neither in the range 00000000H – 00001FFFH nor in the range C0000000H – C0001FFFH.
+
+          • The index is in the range 00000000H – 00001FFFH and the nth bit in read bitmap for low MSRs is 1, where n is
+          the index.
+
+          • The index is in the range C0000000H – C0001FFFH and the nth bit in read bitmap for high MSRs is 1, where n is
+          the logical AND of the index and the value 00001FFFH.
+
+      - value: 79
+        short_name: WRMSRLIST
+        long_name: EXECUTE_WRMSRLIST
+        short_description: WRMSRLIST
+        long_description: |
+          Guest software attempted to execute WRMSRLIST and either the “use MSR bitmaps” VM-execution
+          control was 0 or any of the following holds for the index an MSR being accessed:
+
+          • The index is neither in the range 00000000H – 00001FFFH nor in the range C0000000H – C0001FFFH.
+
+          • The index is in the range 00000000H – 00001FFFH and the nth bit in write bitmap for low MSRs is 1, where n is
+          the index.
+          
+          • The index is in the range C0000000H – C0001FFFH and the nth bit in write bitmap for high MSRs is 1, where n is
+          the logical AND of the index and the value 00001FFFH.
 
     - name: INSTRUCTION_ERROR_NUMBERS
       description: VM-Instruction Error Numbers.


### PR DESCRIPTION
This branch contains new VMX-related definitions that haven't been added to this repository yet. This includes:
- New VM-exit control field bits.
- New VM-entry control field bits.
- New Processor-based control field bits.
- New Basic VM-exit reasons.
- New VMCS field encodings.
- Fixes to some already-defined VMCS field encodings whose values were incorrect.

The definitions were taken from the most recent version of "Intel® 64 and IA-32 Architectures Software Developer's Manual Combined Volumes 3A, 3B, 3C, and 3D: System Programming Guide", that was released on December 2024.